### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*.{pl,pm,t,pod}]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+


### PR DESCRIPTION
This adds an .editorconfig file. This file can be read by editors to force 4-space indentation specified in README. I also added `insert_final_newline` as it is pretty standard. 