### PR TITLE
Rename PAGI::Request param methods for naming consistency

### DIFF
--- a/examples/13-contact-form/app.pl
+++ b/examples/13-contact-form/app.pl
@@ -55,7 +55,7 @@ my $app = async sub {
 async sub _handle_submit {
     my ($req, $send) = @_;
 
-    my $form = await $req->form;
+    my $form = await $req->form_params;
     my @errors;
 
     # Validate required fields

--- a/lib/PAGI/Cookbook.pod
+++ b/lib/PAGI/Cookbook.pod
@@ -1079,7 +1079,7 @@ See C<examples/background-tasks/> for complete working examples.
       my $res = PAGI::Response->new($scope, $send);
 
       if ($req->method eq 'POST') {
-          my $form = await $req->form;
+          my $form = await $req->form_params;
           my $username = $form->{username};
           my $password = $form->{password};
 

--- a/lib/PAGI/Response.pm
+++ b/lib/PAGI/Response.pm
@@ -470,7 +470,7 @@ use L<PAGI::App::File> instead:
 
     async sub handle_contact ($req, $send) {
         my $res = PAGI::Response->new($scope, $send);
-        my $form = await $req->form;
+        my $form = await $req->form_params;
 
         my @errors;
         my $email = $form->get('email') // '';

--- a/lib/PAGI/Tutorial.pod
+++ b/lib/PAGI/Tutorial.pod
@@ -2045,7 +2045,7 @@ L<PAGI::Request> parses HTTP requests and provides convenient accessors for head
 =head3 Query Parameters
 
   # Get single parameter
-  my $page = $req->query('page') // '1';
+  my $page = $req->query_param('page') // '1';
 
   # Get all parameters as Hash::MultiValue
   my $params = $req->query_params;
@@ -2060,8 +2060,11 @@ L<PAGI::Request> parses HTTP requests and provides convenient accessors for head
   my $data = await $req->json;
 
   # Parse URL-encoded form
-  my $form = await $req->form;
+  my $form = await $req->form_params;
   my $name = $form->get('name');
+
+  # Or get a single form value directly
+  my $email = await $req->form_param('email');
 
 Content-type predicates:
 

--- a/t/endpoint/03-http-to-app.t
+++ b/t/endpoint/03-http-to-app.t
@@ -14,7 +14,7 @@ package HelloEndpoint {
 
     async sub get {
         my ($self, $req, $res) = @_;
-        my $name = $req->query('name') // 'World';
+        my $name = $req->query_param('name') // 'World';
         await $res->text("Hello, $name");
     }
 }

--- a/t/request-stash.t
+++ b/t/request-stash.t
@@ -112,7 +112,7 @@ subtest 'path_param only returns path params, not query params' => sub {
 
     # With strict => 0, returns undef
     is($req->path_param('foo', strict => 0), undef, 'strict => 0 returns undef when no path params');
-    is($req->query('foo'), 'bar', 'query() returns query param');
+    is($req->query_param('foo'), 'bar', 'query() returns query param');
 
     # With route params in scope, path_param returns them
     $scope_with_query->{path_params} = { foo => 'route_value' };
@@ -125,7 +125,7 @@ subtest 'path_param only returns path params, not query params' => sub {
         'path_param dies for missing key (does not fall back to query)'
     );
     is($req->path_param('baz', strict => 0), undef, 'strict => 0 returns undef for missing');
-    is($req->query('baz'), 'qux', 'query() returns query param');
+    is($req->query_param('baz'), 'qux', 'query() returns query param');
 };
 
 done_testing;

--- a/t/request/02-query-params.t
+++ b/t/request/02-query-params.t
@@ -25,7 +25,7 @@ subtest 'query_params returns Hash::MultiValue' => sub {
     is(\@foos, ['bar', 'second'], 'get_all returns all values');
 };
 
-subtest 'query() shortcut method' => sub {
+subtest 'query_param() shortcut method' => sub {
     my $scope = {
         type         => 'http',
         method       => 'GET',
@@ -35,9 +35,9 @@ subtest 'query() shortcut method' => sub {
 
     my $req = PAGI::Request->new($scope);
 
-    is($req->query('page'), '5', 'query returns single value');
-    is($req->query('tags'), 'async', 'query returns last for multi');
-    is($req->query('missing'), undef, 'query returns undef for missing');
+    is($req->query_param('page'), '5', 'query returns single value');
+    is($req->query_param('tags'), 'async', 'query returns last for multi');
+    is($req->query_param('missing'), undef, 'query returns undef for missing');
 };
 
 subtest 'percent-decoding' => sub {
@@ -50,8 +50,8 @@ subtest 'percent-decoding' => sub {
 
     my $req = PAGI::Request->new($scope);
 
-    is($req->query('name'), 'John Doe', 'spaces decoded');
-    is($req->query('emoji'), "\x{1F525}", 'UTF-8 emoji decoded');
+    is($req->query_param('name'), 'John Doe', 'spaces decoded');
+    is($req->query_param('emoji'), "\x{1F525}", 'UTF-8 emoji decoded');
 };
 
 subtest 'empty and missing query string' => sub {
@@ -64,7 +64,7 @@ subtest 'empty and missing query string' => sub {
     isa_ok $req1->query_params, 'Hash::MultiValue';
     isa_ok $req2->query_params, 'Hash::MultiValue';
 
-    is($req1->query('foo'), undef, 'missing key returns undef');
+    is($req1->query_param('foo'), undef, 'missing key returns undef');
 };
 
 done_testing;

--- a/t/request/07-params.t
+++ b/t/request/07-params.t
@@ -88,9 +88,9 @@ subtest 'path_param does not include query params' => sub {
         'path_param does not fall back to query params'
     );
 
-    # Query params should be accessed via $req->query('foo')
-    is($req->query('foo'), 'bar', 'query() returns query param');
-    is($req->query('baz'), 'qux', 'query() returns another query param');
+    # Query params should be accessed via $req->query_param('foo')
+    is($req->query_param('foo'), 'bar', 'query() returns query param');
+    is($req->query_param('baz'), 'qux', 'query() returns another query param');
 };
 
 subtest 'path_param_strict mode (class config)' => sub {

--- a/t/request/09-form.t
+++ b/t/request/09-form.t
@@ -19,7 +19,7 @@ sub mock_receive {
     };
 }
 
-subtest 'form parses urlencoded' => sub {
+subtest 'form_params parses urlencoded' => sub {
     my $body = 'name=John%20Doe&email=john%40example.com&tags=perl&tags=async';
     my $scope = {
         type    => 'http',
@@ -29,7 +29,7 @@ subtest 'form parses urlencoded' => sub {
     my $receive = mock_receive($body);
     my $req = PAGI::Request->new($scope, $receive);
 
-    my $form = (async sub { await $req->form })->()->get;
+    my $form = (async sub { await $req->form_params })->()->get;
 
     isa_ok $form, 'Hash::MultiValue';
     is($form->get('name'), 'John Doe', 'name decoded');
@@ -39,7 +39,7 @@ subtest 'form parses urlencoded' => sub {
     is(\@tags, ['perl', 'async'], 'multi-value works');
 };
 
-subtest 'form with UTF-8' => sub {
+subtest 'form_params with UTF-8' => sub {
     my $body = 'message=%E4%BD%A0%E5%A5%BD';  # 你好 URL-encoded
     my $scope = {
         type    => 'http',
@@ -49,12 +49,12 @@ subtest 'form with UTF-8' => sub {
     my $receive = mock_receive($body);
     my $req = PAGI::Request->new($scope, $receive);
 
-    my $form = (async sub { await $req->form })->()->get;
+    my $form = (async sub { await $req->form_params })->()->get;
 
     is($form->get('message'), '你好', 'UTF-8 decoded');
 };
 
-subtest 'form caches result' => sub {
+subtest 'form_params caches result' => sub {
     my $call_count = 0;
     my $scope = {
         type    => 'http',
@@ -67,13 +67,13 @@ subtest 'form caches result' => sub {
     };
     my $req = PAGI::Request->new($scope, $receive);
 
-    (async sub { await $req->form })->()->get;
-    (async sub { await $req->form })->()->get;
+    (async sub { await $req->form_params })->()->get;
+    (async sub { await $req->form_params })->()->get;
 
     is($call_count, 1, 'receive only called once');
 };
 
-subtest 'empty form' => sub {
+subtest 'empty form_params' => sub {
     my $scope = {
         type    => 'http',
         method  => 'POST',
@@ -82,7 +82,7 @@ subtest 'empty form' => sub {
     my $receive = mock_receive('');
     my $req = PAGI::Request->new($scope, $receive);
 
-    my $form = (async sub { await $req->form })->()->get;
+    my $form = (async sub { await $req->form_params })->()->get;
 
     isa_ok $form, 'Hash::MultiValue';
     is([$form->keys], [], 'empty form has no keys');

--- a/t/request/12-uploads.t
+++ b/t/request/12-uploads.t
@@ -86,7 +86,7 @@ subtest 'upload() shortcut for single file' => sub {
     is($missing, undef, 'missing upload returns undef');
 };
 
-subtest 'form() works with multipart' => sub {
+subtest 'form_params() works with multipart' => sub {
     my $boundary = '----Test';
     my $body = build_multipart($boundary,
         { name => 'name', data => 'John' },
@@ -102,7 +102,7 @@ subtest 'form() works with multipart' => sub {
     my $receive = mock_receive($body);
     my $req = PAGI::Request->new($scope, $receive);
 
-    my $form = (async sub { await $req->form })->()->get;
+    my $form = (async sub { await $req->form_params })->()->get;
 
     is($form->get('name'), 'John', 'form field from multipart');
     is($form->get('email'), 'john@example.com', 'another form field');

--- a/t/request/14-integration.t
+++ b/t/request/14-integration.t
@@ -41,7 +41,7 @@ subtest 'full request/response cycle with PAGI::Request' => sub {
             path         => $req->path,
             content_type => $req->content_type,
             is_json      => $req->is_json ? 1 : 0,
-            query        => $req->query('foo'),
+            query        => $req->query_param('foo'),
         };
 
         if ($req->is_post && $req->is_json) {


### PR DESCRIPTION
## Summary

- Rename parameter accessor methods to follow a consistent `*_param`/`*_params` naming pattern (aligning with Dancer2's modern approach)
- Add new singular form accessors: `form_param()` and `raw_form_param()`
- Old method names remain as deprecated aliases that emit warnings via `carp()`

### Method Renames

| Old Name | New Name |
|----------|----------|
| `query($name)` | `query_param($name)` |
| `raw_query($name)` | `raw_query_param($name)` |
| `form(%opts)` | `form_params(%opts)` |
| `raw_form(%opts)` | `raw_form_params(%opts)` |

### New Methods

- `form_param($name, %opts)` - get single form value
- `raw_form_param($name)` - get single raw form value

## Test plan

- [x] All 518 tests pass
- [x] Deprecation warnings work correctly for old method names
- [x] POD documentation renders correctly
- [x] Examples and documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)