### PR TITLE
Add Unix domain socket support

### DIFF
--- a/bin/pagi-server
+++ b/bin/pagi-server
@@ -224,6 +224,13 @@ with C<--host>/C<--port>. Useful for nginx reverse proxy setups:
 
 See L<PAGI::Server/UNIX DOMAIN SOCKET SUPPORT (EXPERIMENTAL)> for details.
 
+=item B<--socket-mode> MODE
+
+Set file permissions on the Unix domain socket (octal, e.g., C<0660>).
+Useful when the reverse proxy runs as a different user:
+
+    pagi-server --socket /tmp/pagi.sock --socket-mode 0660 ./app.pl
+
 =item B<--ssl-cert> FILE, B<--ssl-key> FILE
 
 Enable HTTPS with the specified certificate and key files.

--- a/bin/pagi-server
+++ b/bin/pagi-server
@@ -215,6 +215,15 @@ Number of worker processes (default: 1, single-process mode)
 
 Enable SO_REUSEPORT mode for multi-worker servers.
 
+=item B<--socket> PATH
+
+Listen on a Unix domain socket instead of a TCP port. Mutually exclusive
+with C<--host>/C<--port>. Useful for nginx reverse proxy setups:
+
+    pagi-server --socket /tmp/pagi.sock ./app.pl
+
+See L<PAGI::Server/UNIX DOMAIN SOCKET SUPPORT (EXPERIMENTAL)> for details.
+
 =item B<--ssl-cert> FILE, B<--ssl-key> FILE
 
 Enable HTTPS with the specified certificate and key files.

--- a/lib/PAGI/Runner.pm
+++ b/lib/PAGI/Runner.pm
@@ -537,6 +537,7 @@ sub _parse_server_options {
 
             # Network
             'socket=s'              => \$opts{socket},
+            'socket-mode=s'         => \$opts{socket_mode},
 
             # TLS
             'ssl-cert=s'            => \$opts{_ssl_cert},
@@ -584,6 +585,11 @@ sub _parse_server_options {
         # Handle workers (0 for single-process, >1 for multi-worker)
         if (defined $opts{workers}) {
             $opts{workers} = $opts{workers} > 1 ? $opts{workers} : 0;
+        }
+
+        # Parse socket_mode as octal (CLI passes string like "0660")
+        if (defined $opts{socket_mode}) {
+            $opts{socket_mode} = oct($opts{socket_mode});
         }
     }
 

--- a/lib/PAGI/Runner.pm
+++ b/lib/PAGI/Runner.pm
@@ -506,10 +506,12 @@ sub load_server {
     # else: development mode uses server default (STDERR)
 
     # Build server
+    # When using a Unix socket, omit host/port (they are mutually exclusive)
+    my $use_socket = $server_opts{socket};
     return $server_class->new(
         app        => $self->{app},
-        host       => $self->{host} // '127.0.0.1',
-        port       => $self->{port} // 5000,
+        ($use_socket ? () : (host => $self->{host} // '127.0.0.1')),
+        ($use_socket ? () : (port => $self->{port} // 5000)),
         quiet      => $self->{quiet} // 0,
         ($self->{loop} ? (loop_type => $self->{loop}) : ()),
         (defined $access_log || $disable_log
@@ -532,6 +534,9 @@ sub _parse_server_options {
             'reuseport'             => \$opts{reuseport},
             'max-requests=i'        => \$opts{max_requests},
             'max-connections=i'     => \$opts{max_connections},
+
+            # Network
+            'socket=s'              => \$opts{socket},
 
             # TLS
             'ssl-cert=s'            => \$opts{_ssl_cert},

--- a/t/43-unix-socket.t
+++ b/t/43-unix-socket.t
@@ -1,0 +1,223 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Test2::V0;
+use IO::Async::Loop;
+use IO::Async::Stream;
+use Future::AsyncAwait;
+use IO::Socket::UNIX;
+use File::Temp ();
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use PAGI::Server;
+
+plan skip_all => "Unix sockets not available on Windows" if $^O eq 'MSWin32';
+
+# Helper: generate a unique temporary socket path
+sub tmp_socket_path {
+    my $tmp = File::Temp->new(TEMPLATE => 'pagi-test-XXXXX', SUFFIX => '.sock', TMPDIR => 1);
+    my $path = $tmp->filename;
+    # Remove the temp file — we just need the unique path
+    unlink $path;
+    return $path;
+}
+
+# Simple PAGI app for testing
+my $app = async sub {
+    my ($scope, $receive, $send) = @_;
+    if ($scope->{type} eq 'lifespan') {
+        my $event = await $receive->();
+        if ($event->{type} eq 'lifespan.startup') {
+            await $send->({ type => 'lifespan.startup.complete' });
+        }
+        $event = await $receive->();
+        if ($event && $event->{type} eq 'lifespan.shutdown') {
+            await $send->({ type => 'lifespan.shutdown.complete' });
+        }
+        return;
+    }
+    die "Unsupported: $scope->{type}" unless $scope->{type} eq 'http';
+    await $send->({
+        type    => 'http.response.start',
+        status  => 200,
+        headers => [['content-type', 'text/plain']],
+    });
+    await $send->({
+        type => 'http.response.body',
+        body => "hello from unix socket",
+        more => 0,
+    });
+};
+
+# Helper: send an HTTP request over a Unix socket using the event loop
+async sub http_get_unix {
+    my ($loop, $socket_path) = @_;
+
+    my $sock = IO::Socket::UNIX->new(Peer => $socket_path)
+        or die "Cannot connect to Unix socket $socket_path: $!";
+
+    my $response = '';
+    my $done = $loop->new_future;
+
+    my $stream = IO::Async::Stream->new(
+        handle    => $sock,
+        on_read   => sub {
+            my ($self, $buffref, $eof) = @_;
+            $response .= $$buffref;
+            $$buffref = '';
+            if ($eof) {
+                $done->done($response) unless $done->is_ready;
+            }
+            return 0;
+        },
+        on_read_eof => sub {
+            $done->done($response) unless $done->is_ready;
+        },
+    );
+
+    $loop->add($stream);
+    $stream->write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+
+    # Timeout safety
+    my $timeout = $loop->timeout_future(after => 5);
+    my $result = await Future->wait_any($done, $timeout);
+
+    $loop->remove($stream);
+    return $response;
+}
+
+# Test 1: Socket option is accepted, host/port cleared, accessor works
+subtest 'Socket option accepted and accessor works' => sub {
+    my $socket_path = tmp_socket_path();
+    my $server = PAGI::Server->new(
+        app    => $app,
+        socket => $socket_path,
+        quiet  => 1,
+    );
+
+    is($server->socket_path, $socket_path, 'socket_path accessor returns configured path');
+    is($server->{host}, undef, 'host is cleared when socket is set');
+    is($server->{port}, undef, 'port is cleared when socket is set');
+    ok($server, 'Server created with socket option');
+};
+
+# Test 2: Socket + host is mutually exclusive
+subtest 'Socket and host are mutually exclusive' => sub {
+    my $socket_path = tmp_socket_path();
+    like(
+        dies {
+            PAGI::Server->new(
+                app    => $app,
+                socket => $socket_path,
+                host   => '127.0.0.1',
+                quiet  => 1,
+            );
+        },
+        qr/socket.*host|host.*socket/i,
+        'Dies when both socket and host are specified',
+    );
+};
+
+# Test 3: Socket + port is mutually exclusive
+subtest 'Socket and port are mutually exclusive' => sub {
+    my $socket_path = tmp_socket_path();
+    like(
+        dies {
+            PAGI::Server->new(
+                app    => $app,
+                socket => $socket_path,
+                port   => 5000,
+                quiet  => 1,
+            );
+        },
+        qr/socket.*port|port.*socket/i,
+        'Dies when both socket and port are specified',
+    );
+};
+
+# Test 4: Single-worker listens and responds on Unix socket
+subtest 'Single-worker listens and responds on Unix socket' => sub {
+    my $socket_path = tmp_socket_path();
+    my $loop = IO::Async::Loop->new;
+
+    my $server = PAGI::Server->new(
+        app        => $app,
+        socket     => $socket_path,
+        quiet      => 1,
+        access_log => undef,
+    );
+
+    $loop->add($server);
+    $server->listen->get;
+
+    ok($server->is_running, 'Server is running');
+    ok(-S $socket_path, 'Socket file exists');
+
+    # Send HTTP request via event-loop-driven client
+    my $response = http_get_unix($loop, $socket_path)->get;
+
+    like($response, qr/HTTP\/1\.1 200/, 'Got 200 response');
+    like($response, qr/hello from unix socket/, 'Got expected body');
+
+    $server->shutdown->get;
+    ok(!$server->is_running, 'Server stopped');
+
+    $loop->remove($server);
+};
+
+# Test 5: Socket file cleaned up on shutdown
+subtest 'Socket file cleaned up on shutdown' => sub {
+    my $socket_path = tmp_socket_path();
+    my $loop = IO::Async::Loop->new;
+
+    my $server = PAGI::Server->new(
+        app    => $app,
+        socket => $socket_path,
+        quiet  => 1,
+    );
+
+    $loop->add($server);
+    $server->listen->get;
+
+    ok(-S $socket_path, 'Socket file exists while running');
+
+    $server->shutdown->get;
+
+    ok(! -e $socket_path, 'Socket file removed after shutdown');
+
+    $loop->remove($server);
+};
+
+# Test 6: Stale socket file is removed on startup
+subtest 'Stale socket file removed on startup' => sub {
+    my $socket_path = tmp_socket_path();
+    my $loop = IO::Async::Loop->new;
+
+    # Create a stale socket file
+    my $stale = IO::Socket::UNIX->new(
+        Local  => $socket_path,
+        Listen => 1,
+    ) or die "Cannot create stale socket: $!";
+    close $stale;  # Close it to make it stale
+    ok(-S $socket_path, 'Stale socket file exists');
+
+    my $server = PAGI::Server->new(
+        app    => $app,
+        socket => $socket_path,
+        quiet  => 1,
+    );
+
+    $loop->add($server);
+
+    # Should succeed despite stale socket
+    $server->listen->get;
+    ok($server->is_running, 'Server started despite stale socket');
+    ok(-S $socket_path, 'New socket file exists');
+
+    $server->shutdown->get;
+    $loop->remove($server);
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

- Add `socket => $path` option to PAGI::Server for listening on Unix domain sockets instead of TCP, enabling nginx reverse proxy (`proxy_pass http://unix:/tmp/pagi.sock`) and benchmark (TechEmpower) setups
- Works with both single-worker and multi-worker modes; socket file auto-cleaned on shutdown, stale sockets removed on startup
- Add `--socket PATH` CLI option to pagi-server, with full POD documentation including an experimental feature section
- Add `socket_mode => $octal` option to set file permissions on the socket after creation (e.g., `0660`), useful when the reverse proxy runs as a different user; includes `--socket-mode MODE` CLI flag

Closes #26. Supersedes #31 (re-implemented cleanly on current main).

## Test plan

- [ ] `prove -l t/43-unix-socket.t` — 12 subtests covering option parsing, mutual exclusivity validation, single-worker request/response, multi-worker request/response, socket cleanup, stale socket removal, socket_mode permissions (0660, 0666), default permissions, multi-worker with socket_mode, and socket_mode without socket
- [ ] `prove -l t/` — full test suite passes (no regressions)
- [ ] Manual: `pagi-server --socket /tmp/pagi.sock --socket-mode 0660 ./examples/01-hello-http/app.pl` + `curl --unix-socket /tmp/pagi.sock http://localhost/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)