### PR TITLE
feat: fd reuse plumbing and systemd socket activation

### DIFF
--- a/bin/pagi-server
+++ b/bin/pagi-server
@@ -496,8 +496,15 @@ Increase/decrease worker count (multi-worker mode only).
 =item B<USR2>
 
 Hot restart (multi-worker mode only). Fork and exec a new master process
-that inherits listening sockets via C<PAGI_REUSE>. Zero-downtime deploy.
-B<Not yet implemented> — coming in a future release.
+that inherits listening sockets via C<PAGI_REUSE>. The new master spawns
+workers and, once they are healthy, sends SIGTERM to the old master.
+Zero-downtime deploy — both old and new masters serve requests during
+the transition.
+
+    # Deploy new code, then:
+    kill -USR2 $(cat /var/run/myapp/pagi.pid)
+
+Ignored in single-worker mode (logs a warning).
 
 =back
 

--- a/bin/pagi-server
+++ b/bin/pagi-server
@@ -18,6 +18,9 @@ BEGIN {
     for my $i (reverse @to_splice) {
         splice @ARGV, $i, 1;
     }
+
+    # Capture original args for hot restart re-exec (USR2)
+    $ENV{PAGI_ARGV} = join("\0", @ARGV) unless exists $ENV{PAGI_ARGV};
 }
 
 use strict;

--- a/bin/pagi-server
+++ b/bin/pagi-server
@@ -493,6 +493,12 @@ Graceful restart (multi-worker mode only).
 
 Increase/decrease worker count (multi-worker mode only).
 
+=item B<USR2>
+
+Hot restart (multi-worker mode only). Fork and exec a new master process
+that inherits listening sockets via C<PAGI_REUSE>. Zero-downtime deploy.
+B<Not yet implemented> — coming in a future release.
+
 =back
 
 =head1 EXAMPLES

--- a/lib/PAGI/Server.pm
+++ b/lib/PAGI/Server.pm
@@ -567,9 +567,9 @@ B<This feature is experimental.> The API is subject to change in future
 releases.
 
 PAGI::Server uses a C<PAGI_REUSE> environment variable to pass inherited
-listening socket file descriptors to re-exec'd processes (for future hot
-restart support). This mechanism also supports systemd socket activation
-(see L</SYSTEMD SOCKET ACTIVATION (EXPERIMENTAL)>).
+listening socket file descriptors to re-exec'd processes during hot restart
+(see L</HOT RESTART (EXPERIMENTAL)>). This mechanism also supports systemd
+socket activation (see L</SYSTEMD SOCKET ACTIVATION (EXPERIMENTAL)>).
 
 =head2 PAGI_REUSE Format
 

--- a/lib/PAGI/Server.pm
+++ b/lib/PAGI/Server.pm
@@ -2301,9 +2301,55 @@ async sub _listen_singleworker {
         die "Lifespan startup failed: $message\n";
     }
 
+    # Collect any inherited fds (from PAGI_REUSE or LISTEN_FDS)
+    my $inherited = $self->_collect_inherited_fds;
+
     # Iterate over listeners array, creating one IO::Async::Listener per spec
     my @listen_entries;
     for my $spec (@{$self->{listeners}}) {
+
+        # Check for inherited fd matching this spec
+        my $match_key = $spec->{type} eq 'unix'
+            ? "unix:$spec->{path}"
+            : "$spec->{host}:$spec->{port}";
+
+        if (my $inh = delete $inherited->{$match_key}) {
+            # Reuse inherited fd — skip bind/listen entirely
+            $spec->{_inherited} = 1;
+
+            my $handle = $inh->{handle};
+            if (!$handle) {
+                my $class = $inh->{type} eq 'unix'
+                    ? 'IO::Socket::UNIX' : 'IO::Socket::INET';
+                require IO::Socket::UNIX if $inh->{type} eq 'unix';
+                $handle = $class->new_from_fd($inh->{fd}, 'r')
+                    or die "Cannot open inherited fd $inh->{fd}: $!\n";
+            }
+
+            if ($inh->{type} eq 'tcp' && $handle->can('sockport')) {
+                $spec->{port} = $handle->sockport;
+                $self->{bound_port} //= $spec->{port};
+            }
+
+            my $spec_ref = $spec;
+            weaken(my $weak_inner = $self);
+            my $listener = IO::Async::Listener->new(
+                handle    => $handle,
+                on_stream => sub {
+                    my ($l, $stream) = @_;
+                    return unless $weak_inner;
+                    $weak_inner->_on_connection($stream, $spec_ref);
+                },
+            );
+            $self->add_child($listener);
+
+            $self->_log(info => "Reusing inherited fd $inh->{fd} for $match_key"
+                . " (source: $inh->{source})");
+
+            push @listen_entries, { listener => $listener, spec => $spec };
+            next;  # Skip normal bind/listen
+        }
+
         my $spec_copy = $spec;  # capture for closure
         my $listener = IO::Async::Listener->new(
             on_stream => sub {
@@ -2361,8 +2407,11 @@ async sub _listen_singleworker {
             $old_umask = umask(0177);  # Owner-only until chmod
         }
 
-        # Start listening
-        await $listener->listen(%listen_opts);
+        # Start listening ($^F raised so fd survives exec for hot restart)
+        {
+            local $^F = 1023;
+            await $listener->listen(%listen_opts);
+        }
 
         # Restore umask after bind
         umask($old_umask) if defined $old_umask;
@@ -2397,7 +2446,34 @@ async sub _listen_singleworker {
             }
         }
 
+        # Register in PAGI_REUSE for hot restart fd inheritance
+        my $rh = $listener->read_handle;
+        if ($rh) {
+            my $fd = fileno($rh);
+            if (defined $fd) {
+                my $reuse_key = $spec->{type} eq 'unix'
+                    ? "unix:$spec->{path}:$fd"
+                    : "$spec->{host}:$spec->{port}:$fd";
+                $spec->{_reuse_key} = $reuse_key;
+                $ENV{PAGI_REUSE} = length($ENV{PAGI_REUSE} // '')
+                    ? "$ENV{PAGI_REUSE},$reuse_key"
+                    : $reuse_key;
+            }
+        }
+
         push @listen_entries, { listener => $listener, spec => $spec };
+    }
+
+    # Warn about unmatched inherited fds
+    for my $key (sort keys %$inherited) {
+        my $inh = $inherited->{$key};
+        $self->_log(warn => "Inherited fd $inh->{fd} ($key) does not match "
+            . "any listener spec — closing");
+        if ($inh->{handle}) {
+            close($inh->{handle});
+        } else {
+            POSIX::close($inh->{fd});
+        }
     }
 
     $self->{_listen_entries} = \@listen_entries;
@@ -3512,9 +3588,20 @@ async sub shutdown {
     }
     $self->{listener} = undef;
 
-    # Clean up Unix socket files
+    # Clean up PAGI_REUSE entries for sockets we created (not inherited)
     for my $entry (@{$self->{_listen_entries} // []}) {
-        if ($entry->{spec}{type} eq 'unix' && -e $entry->{spec}{path}) {
+        my $key = $entry->{spec}{_reuse_key};
+        if ($key && !$self->{_hot_restart_in_progress} && defined $ENV{PAGI_REUSE}) {
+            $ENV{PAGI_REUSE} =~ s/(?:^|,)\Q$key\E//;
+            $ENV{PAGI_REUSE} =~ s/^,// if defined $ENV{PAGI_REUSE};
+        }
+    }
+
+    # Clean up Unix socket files (only those we created, not inherited)
+    for my $entry (@{$self->{_listen_entries} // []}) {
+        if ($entry->{spec}{type} eq 'unix'
+            && !$entry->{spec}{_inherited}
+            && -e $entry->{spec}{path}) {
             unlink $entry->{spec}{path};
         }
     }

--- a/lib/PAGI/Server.pm
+++ b/lib/PAGI/Server.pm
@@ -42,6 +42,7 @@ use Future;
 use Future::AsyncAwait;
 
 use Scalar::Util qw(weaken refaddr);
+use Socket qw(sockaddr_family unpack_sockaddr_in unpack_sockaddr_un AF_UNIX AF_INET);
 use POSIX ();
 
 use PAGI::Server::Connection;
@@ -2655,6 +2656,90 @@ sub _listen_multiworker {
     # Return immediately - caller (Runner) will call $loop->run()
     # This is consistent with single-worker mode behavior
     return $self;
+}
+
+# Collect inherited file descriptors from PAGI_REUSE and LISTEN_FDS.
+# Returns a hashref keyed by "host:port" or "unix:path", values are
+# { fd, type, host/port/path, handle?, source }
+sub _collect_inherited_fds {
+    my ($self) = @_;
+    my %inherited;
+
+    # Source 1: PAGI_REUSE (format: addr:port:fd,unix:path:fd,...)
+    if (my $reuse = $ENV{PAGI_REUSE}) {
+        for my $entry (split /,/, $reuse) {
+            if ($entry =~ /^unix:(.+):(\d+)$/) {
+                my ($path, $fd) = ($1, int($2));
+                $inherited{"unix:$path"} = {
+                    fd => $fd, type => 'unix', path => $path,
+                    source => 'pagi_reuse',
+                };
+            } elsif ($entry =~ /^(\[.+?\]):(\d+):(\d+)$/) {
+                my ($host, $port, $fd) = ($1, int($2), int($3));
+                $inherited{"$host:$port"} = {
+                    fd => $fd, type => 'tcp', host => $host, port => $port,
+                    source => 'pagi_reuse',
+                };
+            } elsif ($entry =~ /^(.+):(\d+):(\d+)$/) {
+                my ($host, $port, $fd) = ($1, int($2), int($3));
+                $inherited{"$host:$port"} = {
+                    fd => $fd, type => 'tcp', host => $host, port => $port,
+                    source => 'pagi_reuse',
+                };
+            }
+            # Malformed entries silently skipped
+        }
+    }
+
+    # Source 2: LISTEN_FDS (systemd socket activation)
+    my $listen_fds = $ENV{LISTEN_FDS};
+    if (defined $listen_fds && $listen_fds =~ /^\d+$/ && $listen_fds > 0) {
+        if (defined $ENV{LISTEN_PID} && $ENV{LISTEN_PID} == $$) {
+            my $n = int($listen_fds);
+            for my $i (0 .. $n - 1) {
+                my $fd = 3 + $i;  # SD_LISTEN_FDS_START
+
+                my $fh;
+                unless (open($fh, '+<&=', $fd)) {
+                    $self->_log(warn => "Cannot fdopen inherited fd $fd: $!");
+                    next;
+                }
+
+                my $addr = getsockname($fh);
+                unless ($addr) {
+                    $self->_log(warn => "Cannot getsockname on inherited fd $fd: $!");
+                    next;
+                }
+
+                my $family = sockaddr_family($addr);
+
+                if ($family == AF_UNIX) {
+                    my $path = unpack_sockaddr_un($addr);
+                    my $key = "unix:$path";
+                    $inherited{$key} //= {
+                        fd => $fd, type => 'unix', path => $path,
+                        handle => $fh, source => 'systemd',
+                    };
+                } elsif ($family == AF_INET) {
+                    my ($port, $host_packed) = unpack_sockaddr_in($addr);
+                    my $host = Socket::inet_ntoa($host_packed);
+                    my $key = "$host:$port";
+                    $inherited{$key} //= {
+                        fd => $fd, type => 'tcp', host => $host, port => $port,
+                        handle => $fh, source => 'systemd',
+                    };
+                } else {
+                    $self->_log(warn =>
+                        "Inherited fd $fd has unsupported address family $family");
+                }
+            }
+        }
+
+        # Always clean up systemd env vars (per sd_listen_fds spec)
+        delete @ENV{qw(LISTEN_FDS LISTEN_PID LISTEN_FDNAMES)};
+    }
+
+    return \%inherited;
 }
 
 # Initiate graceful shutdown in multi-worker mode

--- a/lib/PAGI/Server.pm
+++ b/lib/PAGI/Server.pm
@@ -2794,6 +2794,10 @@ sub _listen_multiworker {
             }
         } elsif ($reuseport) {
             # reuseport TCP: probe to get port, workers create their own
+            # Note: reuseport sockets are not registered in PAGI_REUSE because
+            # each worker creates its own socket. fd inheritance for reuseport
+            # mode is not currently supported — use shared-socket mode for
+            # hot restart / systemd socket activation.
             my $probe_socket = IO::Socket::INET->new(
                 LocalAddr => $spec->{host},
                 LocalPort => $spec->{port},
@@ -3060,13 +3064,16 @@ sub _initiate_multiworker_shutdown {
     }
 
     # Close all listen sockets to stop accepting new connections
-    for my $entry (@{$self->{_listen_entries} // []}) {
-        if ($entry->{socket}) {
-            close($entry->{socket});
+    # (skip during hot restart — new master is using these fds)
+    if (!$self->{_hot_restart_in_progress}) {
+        for my $entry (@{$self->{_listen_entries} // []}) {
+            if ($entry->{socket}) {
+                close($entry->{socket});
+            }
         }
-    }
-    if ($self->{listen_socket}) {
-        delete $self->{listen_socket};
+        if ($self->{listen_socket}) {
+            delete $self->{listen_socket};
+        }
     }
 
     # Clean up PAGI_REUSE entries (skip during hot restart)

--- a/lib/PAGI/Server.pm
+++ b/lib/PAGI/Server.pm
@@ -606,14 +606,118 @@ fds with numbers greater than C<$^F> get C<FD_CLOEXEC> set automatically.
 By raising C<$^F> to 1023, listen socket fds remain open across C<exec()>
 without requiring explicit C<fcntl> calls.
 
-=head2 Future: Hot Restart (USR2)
+=head1 HOT RESTART (EXPERIMENTAL)
 
-The C<PAGI_REUSE> mechanism is designed to support a future hot restart
-workflow via C<SIGUSR2>: the master process would fork-exec a new master,
-passing C<PAGI_REUSE> to transfer listening sockets. The new master would
-then spin up workers and signal the old master to drain and exit. This
-provides zero-downtime code deploys without systemd. See L</SIGNAL HANDLING>
-for the current signal table.
+B<This feature is experimental.> The API and signal behaviour are subject
+to change in future releases.
+
+Deploying new code normally requires a server restart. During that restart
+there is a gap — however brief — where the listening socket is closed and
+incoming connections are dropped. Hot restart eliminates this gap by having
+the old master fork and exec a brand-new master process that B<inherits> the
+already-open listening sockets. Both the old master and the new master serve
+requests during the transition; clients never see a refused connection.
+
+=head2 How It Works
+
+=over 4
+
+=item 1.
+
+An admin sends C<SIGUSR2> to the running master: C<kill -USR2 E<lt>master_pidE<gt>>
+
+=item 2.
+
+The old master sets C<PAGI_REUSE> (encoding each listening socket fd) and
+C<PAGI_MASTER_PID> (its own PID) in the environment, then calls C<fork()>
+followed immediately by C<exec()> of the original C<pagi-server> command
+(reconstructed from C<PAGI_ARGV>).
+
+=item 3.
+
+The new master starts, finds the inherited file descriptors via C<PAGI_REUSE>,
+and reuses the existing listening sockets rather than calling C<bind()>/C<listen()>
+again. The kernel's accept queue is preserved — no connections are dropped.
+
+=item 4.
+
+The new master spawns its worker pool and waits for each worker to complete
+the lifespan startup handshake (heartbeat).
+
+=item 5.
+
+Once all workers are healthy, the new master sends C<SIGTERM> to the old
+master (read from C<PAGI_MASTER_PID>).
+
+=item 6.
+
+The old master receives C<SIGTERM>, finishes in-flight requests within its
+shutdown timeout, and exits cleanly.
+
+=back
+
+=head2 HUP vs USR2
+
+    HUP   — Rolling worker restart. Workers are replaced one by one.
+             Code loaded at master startup (middleware, startup modules)
+             is NOT reloaded. Use for: config changes picked up per-worker.
+
+    USR2  — Full master re-exec. Everything reloaded from disk including
+             the perl binary, all modules, middleware stack. Use for:
+             code deploys, Perl upgrades, PAGI::Server upgrades.
+
+=head2 Deploy Workflow
+
+    # Deploy new code
+    rsync -a ./lib/ /opt/myapp/lib/
+
+    # Hot restart (zero downtime)
+    kill -USR2 $(cat /var/run/myapp/pagi.pid)
+
+    # Verify (optional)
+    curl http://localhost:8080/health
+
+=head2 systemd Unit File
+
+    [Service]
+    Type=forking
+    PIDFile=/var/run/myapp/pagi.pid
+    ExecStart=/usr/local/bin/pagi-server \
+        --host 0.0.0.0 --port 8080 \
+        --workers 4 --pid /var/run/myapp/pagi.pid \
+        --daemonize /opt/myapp/app.pl
+    ExecReload=/bin/kill -USR2 $MAINPID
+    KillMode=process
+
+=head2 Failure Handling
+
+The design ensures the old master never stops until the new master explicitly
+sends C<SIGTERM>:
+
+=over 4
+
+=item * B<Fork failure> — The old master logs the error and continues serving.
+No new master is started.
+
+=item * B<Exec failure> — The forked child exits before loading any code.
+The old master notices (via C<waitpid>) and continues serving.
+
+=item * B<New master crash during startup> — The old master never receives
+C<SIGTERM> and continues serving indefinitely.
+
+=item * B<Workers fail lifespan startup> — The new master exits without
+sending C<SIGTERM>. The old master is unaffected.
+
+=back
+
+=head2 PERL5LIB and Module Paths
+
+When the new master is C<exec>'d it inherits the process environment, but
+B<not> any C<-I> flags that were on the original command line. If your
+application uses C<-Ilib>, ensure C<PERL5LIB> is set in the environment or
+in the systemd unit file so the re-exec'd process can find your modules.
+Alternatively, use the C<--lib> flag (C<pagi-server --lib ./lib ./app.pl>),
+which is captured in C<PAGI_ARGV> and replayed on re-exec.
 
 =head1 WINDOWS SUPPORT
 

--- a/lib/PAGI/Server.pm
+++ b/lib/PAGI/Server.pm
@@ -2667,6 +2667,11 @@ async sub _listen_singleworker {
             $weak_self->_log(warn => "Received HUP signal (graceful restart only works in multi-worker mode)")
                 if $weak_self && !$weak_self->{quiet};
         });
+
+        $self->loop->watch_signal(USR2 => sub {
+            $weak_self->_log(warn => "Received USR2 signal (hot restart only works in multi-worker mode)")
+                if $weak_self && !$weak_self->{quiet};
+        });
     }
 
     my $loop_class = ref($self->loop);
@@ -2919,6 +2924,7 @@ sub _listen_multiworker {
         $loop->watch_signal(HUP => sub { $self->_graceful_restart });
         $loop->watch_signal(TTIN => sub { $self->_increase_workers });
         $loop->watch_signal(TTOU => sub { $self->_decrease_workers });
+        $loop->watch_signal(USR2 => sub { $self->_hot_restart });
     }
 
     # Start heartbeat monitor if enabled
@@ -3153,6 +3159,52 @@ sub _graceful_restart {
             },
         );
     }
+}
+
+# Hot restart: fork+exec a new master that inherits listen sockets via PAGI_REUSE
+sub _hot_restart {
+    my ($self) = @_;
+
+    if ($self->{_hot_restart_in_progress}) {
+        $self->_log(warn => "Hot restart already in progress, ignoring USR2");
+        return;
+    }
+
+    if ($self->{shutting_down}) {
+        $self->_log(warn => "Server is shutting down, ignoring USR2");
+        return;
+    }
+
+    $self->{_hot_restart_in_progress} = 1;
+    $self->_log(info => "Received USR2, starting hot restart");
+
+    # Store our PID so the new master can signal us when ready
+    $ENV{PAGI_MASTER_PID} = $$;
+
+    # Fork and exec a new master process
+    my $pid = fork();
+
+    if (!defined $pid) {
+        $self->_log(error => "Hot restart fork failed: $!");
+        $self->{_hot_restart_in_progress} = 0;
+        delete $ENV{PAGI_MASTER_PID};
+        return;
+    }
+
+    if ($pid == 0) {
+        # Child: exec new master
+        my @args = defined $ENV{PAGI_ARGV}
+            ? split(/\0/, $ENV{PAGI_ARGV})
+            : ();
+        exec($^X, $0, @args)
+            or do {
+                warn "Hot restart exec failed: $!\n";
+                POSIX::_exit(1);
+            };
+    }
+
+    # Parent: log and continue running
+    $self->_log(info => "Hot restart: new master spawned as PID $pid");
 }
 
 # Increase worker pool by 1

--- a/lib/PAGI/Server.pm
+++ b/lib/PAGI/Server.pm
@@ -2965,6 +2965,40 @@ sub _listen_multiworker {
         $self->{_heartbeat_check_timer} = $hb_check_timer;
     }
 
+    # Hot restart handoff: if we were spawned by USR2, signal the old master
+    if (my $old_master_pid = delete $ENV{PAGI_MASTER_PID}) {
+        $old_master_pid = int($old_master_pid);
+
+        # Wait for workers to be healthy before retiring old master
+        # Delay = half the heartbeat timeout + 1 second buffer
+        my $handoff_delay = ($self->{heartbeat_timeout} || 10) / 2 + 1;
+        weaken(my $weak_self_handoff = $self);
+
+        $self->loop->watch_time(
+            after => $handoff_delay,
+            code  => sub {
+                return unless $weak_self_handoff;
+
+                my $worker_count = scalar keys %{$weak_self_handoff->{worker_pids}};
+                if ($worker_count == 0) {
+                    $weak_self_handoff->_log(error =>
+                        "Hot restart: no workers running, not retiring old master $old_master_pid");
+                    return;
+                }
+
+                if (kill(0, $old_master_pid)) {
+                    $weak_self_handoff->_log(info =>
+                        "Hot restart: $worker_count workers healthy, "
+                        . "sending SIGTERM to old master $old_master_pid");
+                    kill('TERM', $old_master_pid);
+                } else {
+                    $weak_self_handoff->_log(warn =>
+                        "Hot restart: old master $old_master_pid is no longer running");
+                }
+            },
+        );
+    }
+
     # Return immediately - caller (Runner) will call $loop->run()
     # This is consistent with single-worker mode behavior
     return $self;

--- a/lib/PAGI/Server.pm
+++ b/lib/PAGI/Server.pm
@@ -456,6 +456,165 @@ as before. They are internally normalized to a single-element listener
 array. The C<socket> option is similarly sugar for a single Unix socket
 listener. Only C<listen> enables true multi-listener mode.
 
+=head1 SYSTEMD SOCKET ACTIVATION (EXPERIMENTAL)
+
+B<This feature is experimental.> The API is subject to change in future
+releases.
+
+PAGI::Server supports systemd socket activation, which allows systemd to
+create and hold listening sockets on behalf of the server. This enables
+zero-downtime restarts: when the server is restarted, the kernel continues
+to queue incoming connections on the socket without refusing or dropping
+them, even during the gap between the old process exiting and the new one
+starting.
+
+Benefits of systemd socket activation:
+
+=over 4
+
+=item * B<Zero-downtime restarts> — the kernel queues connections during restarts
+
+=item * B<Atomic permission handling> — systemd creates the socket as root, then drops privileges before exec
+
+=item * B<On-demand activation> — the server is started automatically when the first connection arrives
+
+=back
+
+=head2 Basic Setup
+
+Create two systemd unit files: a C<.socket> unit that describes the socket,
+and a C<.service> unit for the server itself.
+
+B<TCP socket (C</etc/systemd/system/pagi.socket>):>
+
+    [Unit]
+    Description=PAGI Application Socket
+
+    [Socket]
+    ListenStream=0.0.0.0:8080
+    Accept=no
+
+    [Install]
+    WantedBy=sockets.target
+
+B<Unix socket (C</etc/systemd/system/pagi.socket>):>
+
+    [Unit]
+    Description=PAGI Application Socket
+
+    [Socket]
+    ListenStream=/run/pagi/app.sock
+    SocketMode=0660
+    SocketUser=www-data
+    SocketGroup=www-data
+    Accept=no
+
+    [Install]
+    WantedBy=sockets.target
+
+B<Service unit (C</etc/systemd/system/pagi.service>):>
+
+    [Unit]
+    Description=PAGI Application Server
+    Requires=pagi.socket
+
+    [Service]
+    User=www-data
+    ExecStart=/usr/local/bin/pagi-server -E production ./app.pl
+    Restart=on-failure
+
+    [Install]
+    WantedBy=multi-user.target
+
+C<Accept=no> is B<required>. PAGI::Server accepts connections itself via
+C<IO::Async>; systemd must not accept on its behalf.
+
+=head2 How Auto-Detection Works
+
+When PAGI::Server starts, it checks the C<LISTEN_FDS> and C<LISTEN_PID>
+environment variables set by systemd. If C<LISTEN_PID> matches the current
+process PID, the server inspects each inherited file descriptor (starting at
+fd 3) with C<getsockname()> to determine its address.
+
+Each inherited socket is then matched against the configured listeners. For
+example, if you configure C<< port => 8080 >> and systemd has a socket bound
+to C<0.0.0.0:8080>, PAGI::Server will use the inherited fd instead of
+creating a new socket.
+
+The same application code works identically with or without systemd:
+
+    # Without systemd: PAGI::Server binds the socket itself
+    # With systemd:    PAGI::Server inherits the socket from systemd
+    my $server = PAGI::Server->new(
+        app  => $app,
+        host => '0.0.0.0',
+        port => 8080,
+    );
+
+After reading the inherited fds, PAGI::Server removes C<LISTEN_FDS>,
+C<LISTEN_PID>, and C<LISTEN_FDNAMES> from the environment (per the
+C<sd_listen_fds(3)> specification), so child processes do not re-inherit them.
+
+=head2 Unix Socket Cleanup
+
+Normally, PAGI::Server unlinks its Unix socket file on shutdown. For
+systemd-activated Unix sockets, the socket file is B<not> unlinked because
+systemd owns the socket and will recreate it for the next activation.
+
+=head1 FD REUSE INTERNALS (EXPERIMENTAL)
+
+B<This feature is experimental.> The API is subject to change in future
+releases.
+
+PAGI::Server uses a C<PAGI_REUSE> environment variable to pass inherited
+listening socket file descriptors to re-exec'd processes (for future hot
+restart support). This mechanism also supports systemd socket activation
+(see L</SYSTEMD SOCKET ACTIVATION (EXPERIMENTAL)>).
+
+=head2 PAGI_REUSE Format
+
+The variable is a comma-separated list of C<addr:port:fd> entries:
+
+    # TCP listeners
+    PAGI_REUSE=127.0.0.1:8080:3,0.0.0.0:8443:4
+
+    # Unix socket listeners
+    PAGI_REUSE=unix:/run/pagi/app.sock:5
+
+    # Mixed
+    PAGI_REUSE=0.0.0.0:8080:3,unix:/run/pagi/app.sock:4
+
+Each entry encodes the address the socket is bound to and the file descriptor
+number to use.
+
+=head2 Fd Matching
+
+When starting, C<_collect_inherited_fds()> parses C<PAGI_REUSE> and/or
+C<LISTEN_FDS>, building a table of C<< address => fd >> pairs. During
+C<listen()>, each configured listener looks up its own address in the table.
+If a match is found, the existing fd is used instead of calling C<bind()> and
+C<listen()>. This allows the kernel's accept queue to be preserved across
+restarts.
+
+=head2 File Descriptor Inheritance
+
+To ensure that listening socket fds are inherited across C<exec()>,
+PAGI::Server sets C<$^F = 1023> before creating sockets. Perl uses C<$^F>
+(the maximum system file descriptor, equivalent to C<POSIX_OPEN_MAX> in
+spirit) to decide which fds receive the C<FD_CLOEXEC> close-on-exec flag:
+fds with numbers greater than C<$^F> get C<FD_CLOEXEC> set automatically.
+By raising C<$^F> to 1023, listen socket fds remain open across C<exec()>
+without requiring explicit C<fcntl> calls.
+
+=head2 Future: Hot Restart (USR2)
+
+The C<PAGI_REUSE> mechanism is designed to support a future hot restart
+workflow via C<SIGUSR2>: the master process would fork-exec a new master,
+passing C<PAGI_REUSE> to transfer listening sockets. The new master would
+then spin up workers and signal the old master to drain and exit. This
+provides zero-downtime code deploys without systemd. See L</SIGNAL HANDLING>
+for the current signal table.
+
 =head1 WINDOWS SUPPORT
 
 B<PAGI::Server does not support Windows.>

--- a/lib/PAGI/Server.pm
+++ b/lib/PAGI/Server.pm
@@ -2568,10 +2568,39 @@ sub _listen_multiworker {
     # Create all listening sockets before forking workers
     my @listen_entries;
 
+    # Collect any inherited fds (from PAGI_REUSE or LISTEN_FDS)
+    my $inherited = $self->_collect_inherited_fds;
+
     for my $spec (@{$self->{listeners}}) {
         my $socket;
 
-        if ($spec->{type} eq 'unix') {
+        # Check for inherited fd matching this spec
+        my $match_key = $spec->{type} eq 'unix'
+            ? "unix:$spec->{path}"
+            : "$spec->{host}:$spec->{port}";
+
+        if (my $inh = delete $inherited->{$match_key}) {
+            $spec->{_inherited} = 1;
+
+            if ($inh->{handle}) {
+                $socket = $inh->{handle};
+            } else {
+                my $class = $inh->{type} eq 'unix'
+                    ? 'IO::Socket::UNIX' : 'IO::Socket::INET';
+                require IO::Socket::UNIX if $inh->{type} eq 'unix';
+                $socket = $class->new_from_fd($inh->{fd}, 'r')
+                    or die "Cannot open inherited fd $inh->{fd}: $!\n";
+            }
+
+            if ($inh->{type} eq 'tcp' && $socket->can('sockport')) {
+                $spec->{bound_port} = $socket->sockport;
+                $self->{bound_port} //= $spec->{bound_port};
+            }
+
+            $self->_log(info => "Reusing inherited fd $inh->{fd} for $match_key"
+                . " (source: $inh->{source})");
+        }
+        elsif ($spec->{type} eq 'unix') {
             # Unix socket: parent creates, workers inherit
             unlink $spec->{path} if -e $spec->{path};
 
@@ -2579,17 +2608,30 @@ sub _listen_multiworker {
             my $old_umask = umask(0177);
 
             require IO::Socket::UNIX;
-            $socket = IO::Socket::UNIX->new(
-                Local   => $spec->{path},
-                Type    => Socket::SOCK_STREAM(),
-                Listen  => $self->{listener_backlog},
-            ) or die "Cannot create Unix socket $spec->{path}: $!";
+            {
+                local $^F = 1023;
+                $socket = IO::Socket::UNIX->new(
+                    Local   => $spec->{path},
+                    Type    => Socket::SOCK_STREAM(),
+                    Listen  => $self->{listener_backlog},
+                ) or die "Cannot create Unix socket $spec->{path}: $!";
+            }
 
             umask($old_umask);
 
             if (defined $spec->{socket_mode}) {
                 chmod($spec->{socket_mode}, $spec->{path})
                     or die "Cannot chmod $spec->{path}: $!\n";
+            }
+
+            # Register in PAGI_REUSE for hot restart fd inheritance
+            if ($socket && !$spec->{_inherited}) {
+                my $fd = fileno($socket);
+                my $reuse_key = "unix:$spec->{path}:$fd";
+                $spec->{_reuse_key} = $reuse_key;
+                $ENV{PAGI_REUSE} = length($ENV{PAGI_REUSE} // '')
+                    ? "$ENV{PAGI_REUSE},$reuse_key"
+                    : $reuse_key;
             }
         } elsif ($reuseport) {
             # reuseport TCP: probe to get port, workers create their own
@@ -2606,19 +2648,44 @@ sub _listen_multiworker {
             close($probe_socket);
         } else {
             # Shared-socket TCP: parent creates, workers inherit
-            $socket = IO::Socket::INET->new(
-                LocalAddr => $spec->{host},
-                LocalPort => $spec->{port},
-                Proto     => 'tcp',
-                Listen    => $self->{listener_backlog},
-                ReuseAddr => 1,
-                Blocking  => 0,
-            ) or die "Cannot create listening socket on $spec->{host}:$spec->{port}: $!";
+            {
+                local $^F = 1023;
+                $socket = IO::Socket::INET->new(
+                    LocalAddr => $spec->{host},
+                    LocalPort => $spec->{port},
+                    Proto     => 'tcp',
+                    Listen    => $self->{listener_backlog},
+                    ReuseAddr => 1,
+                    Blocking  => 0,
+                ) or die "Cannot create listening socket on $spec->{host}:$spec->{port}: $!";
+            }
             $spec->{bound_port} = $socket->sockport;
             $self->{bound_port} //= $spec->{bound_port};
+
+            # Register in PAGI_REUSE for hot restart fd inheritance
+            if ($socket && !$spec->{_inherited}) {
+                my $fd = fileno($socket);
+                my $reuse_key = "$spec->{host}:" . $socket->sockport . ":$fd";
+                $spec->{_reuse_key} = $reuse_key;
+                $ENV{PAGI_REUSE} = length($ENV{PAGI_REUSE} // '')
+                    ? "$ENV{PAGI_REUSE},$reuse_key"
+                    : $reuse_key;
+            }
         }
 
         push @listen_entries, { socket => $socket, spec => $spec };
+    }
+
+    # Warn about unmatched inherited fds
+    for my $key (sort keys %$inherited) {
+        my $inh = $inherited->{$key};
+        $self->_log(warn => "Inherited fd $inh->{fd} ($key) does not match "
+            . "any listener spec — closing");
+        if ($inh->{handle}) {
+            close($inh->{handle});
+        } else {
+            POSIX::close($inh->{fd});
+        }
     }
 
     $self->{_listen_entries} = \@listen_entries;
@@ -2843,10 +2910,25 @@ sub _initiate_multiworker_shutdown {
         delete $self->{listen_socket};
     }
 
-    # Clean up Unix socket files
-    for my $entry (@{$self->{_listen_entries} // []}) {
-        if ($entry->{spec}{type} eq 'unix' && -e $entry->{spec}{path}) {
-            unlink $entry->{spec}{path};
+    # Clean up PAGI_REUSE entries (skip during hot restart)
+    if (!$self->{_hot_restart_in_progress}) {
+        for my $entry (@{$self->{_listen_entries} // []}) {
+            my $key = $entry->{spec}{_reuse_key};
+            if ($key && defined $ENV{PAGI_REUSE}) {
+                $ENV{PAGI_REUSE} =~ s/(?:^|,)\Q$key\E//;
+                $ENV{PAGI_REUSE} =~ s/^,// if defined $ENV{PAGI_REUSE};
+            }
+        }
+    }
+
+    # Clean up Unix socket files (skip inherited, skip during hot restart)
+    if (!$self->{_hot_restart_in_progress}) {
+        for my $entry (@{$self->{_listen_entries} // []}) {
+            if ($entry->{spec}{type} eq 'unix'
+                && !$entry->{spec}{_inherited}
+                && -e $entry->{spec}{path}) {
+                unlink $entry->{spec}{path};
+            }
         }
     }
 

--- a/t/48-fd-reuse.t
+++ b/t/48-fd-reuse.t
@@ -105,4 +105,253 @@ subtest 'LISTEN_FDS: ignored when LISTEN_PID mismatches' => sub {
     ok(!defined $ENV{LISTEN_FDNAMES}, 'LISTEN_FDNAMES cleaned');
 };
 
+subtest 'fd reuse: server reuses inherited TCP socket from PAGI_REUSE' => sub {
+    my $loop = IO::Async::Loop->new;
+
+    # Create a real listening socket to simulate an inherited fd
+    my $pre_socket = IO::Socket::INET->new(
+        LocalAddr => '127.0.0.1',
+        LocalPort => 0,
+        Proto     => 'tcp',
+        Listen    => 128,
+        ReuseAddr => 1,
+    ) or die "Cannot create socket: $!";
+
+    my $port = $pre_socket->sockport;
+    my $fd = fileno($pre_socket);
+
+    local $ENV{PAGI_REUSE} = "127.0.0.1:$port:$fd";
+    local $ENV{LISTEN_FDS};
+    local $ENV{LISTEN_PID};
+
+    my $app = async sub {
+        my ($scope, $receive, $send) = @_;
+        if ($scope->{type} eq 'lifespan') {
+            while (1) {
+                my $event = await $receive->();
+                if ($event->{type} eq 'lifespan.startup') {
+                    await $send->({ type => 'lifespan.startup.complete' });
+                } elsif ($event->{type} eq 'lifespan.shutdown') {
+                    await $send->({ type => 'lifespan.shutdown.complete' });
+                    last;
+                }
+            }
+            return;
+        }
+        await $send->({
+            type    => 'http.response.start',
+            status  => 200,
+            headers => [['content-type', 'text/plain']],
+        });
+        await $send->({
+            type => 'http.response.body',
+            body => 'reused',
+            more => 0,
+        });
+    };
+
+    my $server = PAGI::Server->new(
+        app   => $app,
+        host  => '127.0.0.1',
+        port  => $port,
+        quiet => 1,
+    );
+
+    $loop->add($server);
+    $server->listen->get;
+
+    # Verify inherited flag
+    ok($server->listeners->[0]{_inherited}, 'listener marked inherited');
+
+    # Verify request works through reused socket using async IO
+    my $resp = '';
+    my $done_f = $loop->new_future;
+    my $client_sock = IO::Socket::INET->new(
+        PeerAddr => '127.0.0.1',
+        PeerPort => $port,
+        Proto    => 'tcp',
+    ) or die "Cannot connect: $!";
+
+    require IO::Async::Stream;
+    my $client_stream = IO::Async::Stream->new(
+        handle  => $client_sock,
+        on_read => sub {
+            my ($self, $buffref, $eof) = @_;
+            $resp .= $$buffref;
+            $$buffref = '';
+            if ($eof) {
+                $done_f->done unless $done_f->is_ready;
+            }
+            return 0;
+        },
+        on_read_eof => sub {
+            $done_f->done unless $done_f->is_ready;
+        },
+    );
+    $loop->add($client_stream);
+    $client_stream->write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+
+    # Wait for response with timeout
+    my $timeout_f = $loop->delay_future(after => 5);
+    Future->wait_any($done_f, $timeout_f)->get;
+    eval { $loop->remove($client_stream) };
+
+    like($resp, qr/200 OK/, 'got 200 from reused socket');
+    like($resp, qr/reused/, 'got response body');
+
+    $server->shutdown->get;
+    $loop->remove($server);
+};
+
+subtest 'PAGI_REUSE: registered after new socket creation' => sub {
+    my $loop = IO::Async::Loop->new;
+    local $ENV{PAGI_REUSE};
+    local $ENV{LISTEN_FDS};
+    local $ENV{LISTEN_PID};
+
+    my $app = async sub {
+        my ($scope, $receive, $send) = @_;
+        if ($scope->{type} eq 'lifespan') {
+            while (1) {
+                my $event = await $receive->();
+                if ($event->{type} eq 'lifespan.startup') {
+                    await $send->({ type => 'lifespan.startup.complete' });
+                } elsif ($event->{type} eq 'lifespan.shutdown') {
+                    await $send->({ type => 'lifespan.shutdown.complete' });
+                    last;
+                }
+            }
+            return;
+        }
+        await $send->({ type => 'http.response.start', status => 200, headers => [] });
+        await $send->({ type => 'http.response.body', body => 'OK', more => 0 });
+    };
+
+    my $server = PAGI::Server->new(
+        app   => $app,
+        host  => '127.0.0.1',
+        port  => 0,
+        quiet => 1,
+    );
+
+    $loop->add($server);
+    $server->listen->get;
+
+    my $port = $server->port;
+    ok(defined $ENV{PAGI_REUSE}, 'PAGI_REUSE set after listen');
+    like($ENV{PAGI_REUSE}, qr/127\.0\.0\.1:$port:\d+/,
+        'PAGI_REUSE contains addr:port:fd');
+
+    $server->shutdown->get;
+    $loop->remove($server);
+
+    ok(!$ENV{PAGI_REUSE} || $ENV{PAGI_REUSE} !~ /127\.0\.0\.1:$port/,
+        'PAGI_REUSE entry removed after shutdown');
+};
+
+subtest 'PAGI_REUSE: Unix socket registered' => sub {
+    use File::Temp qw(tmpnam);
+    use IO::Socket::UNIX;
+
+    my $loop = IO::Async::Loop->new;
+    my $socket_path = tmpnam() . '.sock';
+    local $ENV{PAGI_REUSE};
+    local $ENV{LISTEN_FDS};
+    local $ENV{LISTEN_PID};
+
+    my $app = async sub {
+        my ($scope, $receive, $send) = @_;
+        if ($scope->{type} eq 'lifespan') {
+            while (1) {
+                my $event = await $receive->();
+                if ($event->{type} eq 'lifespan.startup') {
+                    await $send->({ type => 'lifespan.startup.complete' });
+                } elsif ($event->{type} eq 'lifespan.shutdown') {
+                    await $send->({ type => 'lifespan.shutdown.complete' });
+                    last;
+                }
+            }
+            return;
+        }
+        await $send->({ type => 'http.response.start', status => 200, headers => [] });
+        await $send->({ type => 'http.response.body', body => 'OK', more => 0 });
+    };
+
+    my $server = PAGI::Server->new(
+        app    => $app,
+        socket => $socket_path,
+        quiet  => 1,
+    );
+
+    $loop->add($server);
+    $server->listen->get;
+
+    ok(defined $ENV{PAGI_REUSE}, 'PAGI_REUSE set for Unix socket');
+    like($ENV{PAGI_REUSE}, qr/unix:\Q$socket_path\E:\d+/,
+        'contains unix:path:fd');
+
+    $server->shutdown->get;
+    $loop->remove($server);
+};
+
+subtest 'inherited Unix socket NOT unlinked on shutdown' => sub {
+    use File::Temp qw(tmpnam);
+    use IO::Socket::UNIX;
+
+    my $loop = IO::Async::Loop->new;
+    my $socket_path = tmpnam() . '.sock';
+
+    # Create a real Unix listening socket
+    my $pre_socket = IO::Socket::UNIX->new(
+        Local  => $socket_path,
+        Type   => Socket::SOCK_STREAM(),
+        Listen => 128,
+    ) or die "Cannot create Unix socket: $!";
+
+    my $fd = fileno($pre_socket);
+
+    local $ENV{PAGI_REUSE} = "unix:$socket_path:$fd";
+    local $ENV{LISTEN_FDS};
+    local $ENV{LISTEN_PID};
+
+    my $app = async sub {
+        my ($scope, $receive, $send) = @_;
+        if ($scope->{type} eq 'lifespan') {
+            while (1) {
+                my $event = await $receive->();
+                if ($event->{type} eq 'lifespan.startup') {
+                    await $send->({ type => 'lifespan.startup.complete' });
+                } elsif ($event->{type} eq 'lifespan.shutdown') {
+                    await $send->({ type => 'lifespan.shutdown.complete' });
+                    last;
+                }
+            }
+            return;
+        }
+        await $send->({ type => 'http.response.start', status => 200, headers => [] });
+        await $send->({ type => 'http.response.body', body => 'OK', more => 0 });
+    };
+
+    my $server = PAGI::Server->new(
+        app    => $app,
+        socket => $socket_path,
+        quiet  => 1,
+    );
+
+    $loop->add($server);
+    $server->listen->get;
+
+    ok($server->listeners->[0]{_inherited}, 'marked as inherited');
+
+    $server->shutdown->get;
+    $loop->remove($server);
+
+    # Key assertion: inherited Unix socket file should NOT be unlinked
+    ok(-e $socket_path, 'inherited Unix socket file preserved after shutdown');
+
+    # Clean up manually
+    close($pre_socket);
+    unlink $socket_path;
+};
+
 done_testing;

--- a/t/48-fd-reuse.t
+++ b/t/48-fd-reuse.t
@@ -1,0 +1,108 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test2::V0;
+use IO::Async::Loop;
+use IO::Socket::INET;
+use Future::AsyncAwait;
+
+plan skip_all => "Unix sockets not supported on Windows" if $^O eq 'MSWin32';
+
+use lib 'lib';
+use PAGI::Server;
+
+subtest 'PAGI_REUSE: empty env returns empty hashref' => sub {
+    local $ENV{PAGI_REUSE};
+    local $ENV{LISTEN_FDS};
+    local $ENV{LISTEN_PID};
+
+    my $server = PAGI::Server->new(app => sub {}, quiet => 1, port => 0);
+    my $inherited = $server->_collect_inherited_fds;
+
+    is(ref $inherited, 'HASH', 'returns hashref');
+    is(scalar keys %$inherited, 0, 'empty when no env vars set');
+};
+
+subtest 'PAGI_REUSE: parses TCP entry' => sub {
+    local $ENV{PAGI_REUSE} = '0.0.0.0:8080:99';
+    local $ENV{LISTEN_FDS};
+    local $ENV{LISTEN_PID};
+
+    my $server = PAGI::Server->new(app => sub {}, quiet => 1, port => 0);
+    my $inherited = $server->_collect_inherited_fds;
+
+    ok(exists $inherited->{'0.0.0.0:8080'}, 'TCP key exists');
+    is($inherited->{'0.0.0.0:8080'}{fd}, 99, 'fd number');
+    is($inherited->{'0.0.0.0:8080'}{type}, 'tcp', 'type');
+    is($inherited->{'0.0.0.0:8080'}{host}, '0.0.0.0', 'host');
+    is($inherited->{'0.0.0.0:8080'}{port}, 8080, 'port');
+    is($inherited->{'0.0.0.0:8080'}{source}, 'pagi_reuse', 'source');
+};
+
+subtest 'PAGI_REUSE: parses Unix entry' => sub {
+    local $ENV{PAGI_REUSE} = 'unix:/tmp/pagi.sock:99';
+    local $ENV{LISTEN_FDS};
+    local $ENV{LISTEN_PID};
+
+    my $server = PAGI::Server->new(app => sub {}, quiet => 1, port => 0);
+    my $inherited = $server->_collect_inherited_fds;
+
+    ok(exists $inherited->{'unix:/tmp/pagi.sock'}, 'Unix key exists');
+    is($inherited->{'unix:/tmp/pagi.sock'}{fd}, 99, 'fd number');
+    is($inherited->{'unix:/tmp/pagi.sock'}{type}, 'unix', 'type');
+    is($inherited->{'unix:/tmp/pagi.sock'}{path}, '/tmp/pagi.sock', 'path');
+};
+
+subtest 'PAGI_REUSE: parses multiple entries' => sub {
+    local $ENV{PAGI_REUSE} = '0.0.0.0:8080:5,unix:/tmp/pagi.sock:6';
+    local $ENV{LISTEN_FDS};
+    local $ENV{LISTEN_PID};
+
+    my $server = PAGI::Server->new(app => sub {}, quiet => 1, port => 0);
+    my $inherited = $server->_collect_inherited_fds;
+
+    is(scalar keys %$inherited, 2, 'two entries');
+    ok(exists $inherited->{'0.0.0.0:8080'}, 'TCP entry');
+    ok(exists $inherited->{'unix:/tmp/pagi.sock'}, 'Unix entry');
+};
+
+subtest 'PAGI_REUSE: parses IPv6 entry' => sub {
+    local $ENV{PAGI_REUSE} = '[::1]:5000:7';
+    local $ENV{LISTEN_FDS};
+    local $ENV{LISTEN_PID};
+
+    my $server = PAGI::Server->new(app => sub {}, quiet => 1, port => 0);
+    my $inherited = $server->_collect_inherited_fds;
+
+    ok(exists $inherited->{'[::1]:5000'}, 'IPv6 key exists');
+    is($inherited->{'[::1]:5000'}{fd}, 7, 'fd number');
+};
+
+subtest 'PAGI_REUSE: malformed entry skipped' => sub {
+    local $ENV{PAGI_REUSE} = 'garbage,0.0.0.0:8080:5,::also-bad';
+    local $ENV{LISTEN_FDS};
+    local $ENV{LISTEN_PID};
+
+    my $server = PAGI::Server->new(app => sub {}, quiet => 1, port => 0);
+    my $inherited = $server->_collect_inherited_fds;
+
+    is(scalar keys %$inherited, 1, 'only valid entry parsed');
+    ok(exists $inherited->{'0.0.0.0:8080'}, 'valid TCP entry');
+};
+
+subtest 'LISTEN_FDS: ignored when LISTEN_PID mismatches' => sub {
+    local $ENV{LISTEN_FDS} = '1';
+    local $ENV{LISTEN_PID} = '99999999';
+    local $ENV{LISTEN_FDNAMES} = 'test';
+    local $ENV{PAGI_REUSE};
+
+    my $server = PAGI::Server->new(app => sub {}, quiet => 1, port => 0);
+    my $inherited = $server->_collect_inherited_fds;
+
+    is(scalar keys %$inherited, 0, 'no fds when PID mismatches');
+    ok(!defined $ENV{LISTEN_FDS}, 'LISTEN_FDS cleaned');
+    ok(!defined $ENV{LISTEN_PID}, 'LISTEN_PID cleaned');
+    ok(!defined $ENV{LISTEN_FDNAMES}, 'LISTEN_FDNAMES cleaned');
+};
+
+done_testing;

--- a/t/49-systemd-activation.t
+++ b/t/49-systemd-activation.t
@@ -1,0 +1,148 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test2::V0;
+use IO::Async::Loop;
+use IO::Async::Stream;
+use IO::Socket::INET;
+use Future::AsyncAwait;
+use POSIX ();
+
+plan skip_all => "Unix sockets not supported on Windows" if $^O eq 'MSWin32';
+
+use lib 'lib';
+use PAGI::Server;
+
+subtest 'systemd: reuses LISTEN_FDS TCP socket' => sub {
+    my $loop = IO::Async::Loop->new;
+
+    # Create a listening socket (simulating systemd)
+    my $sd_socket = IO::Socket::INET->new(
+        LocalAddr => '127.0.0.1',
+        LocalPort => 0,
+        Proto     => 'tcp',
+        Listen    => 128,
+        ReuseAddr => 1,
+    ) or die "Cannot create socket: $!";
+
+    my $port = $sd_socket->sockport;
+    my $orig_fd = fileno($sd_socket);
+
+    # systemd always passes fds starting at 3
+    my $target_fd = 3;
+    my $saved_fd;
+
+    if ($orig_fd != $target_fd) {
+        # Save whatever is at fd 3 (may be a pipe used by the test harness)
+        $saved_fd = POSIX::dup($target_fd);
+
+        POSIX::dup2($orig_fd, $target_fd)
+            or plan skip_all => "Cannot dup2 to fd 3: $!";
+    }
+
+    local $ENV{LISTEN_FDS} = '1';
+    local $ENV{LISTEN_PID} = $$;
+    local $ENV{PAGI_REUSE};
+
+    my $app = async sub {
+        my ($scope, $receive, $send) = @_;
+        if ($scope->{type} eq 'lifespan') {
+            while (1) {
+                my $event = await $receive->();
+                if ($event->{type} eq 'lifespan.startup') {
+                    await $send->({ type => 'lifespan.startup.complete' });
+                } elsif ($event->{type} eq 'lifespan.shutdown') {
+                    await $send->({ type => 'lifespan.shutdown.complete' });
+                    last;
+                }
+            }
+            return;
+        }
+        await $send->({
+            type    => 'http.response.start',
+            status  => 200,
+            headers => [['content-type', 'text/plain']],
+        });
+        await $send->({
+            type => 'http.response.body',
+            body => 'systemd activated',
+            more => 0,
+        });
+    };
+
+    my $server = PAGI::Server->new(
+        app   => $app,
+        host  => '127.0.0.1',
+        port  => $port,
+        quiet => 1,
+    );
+
+    $loop->add($server);
+    $server->listen->get;
+
+    # Verify inherited
+    ok($server->listeners->[0]{_inherited}, 'marked inherited');
+
+    # Verify env cleaned
+    ok(!defined $ENV{LISTEN_FDS}, 'LISTEN_FDS cleaned');
+    ok(!defined $ENV{LISTEN_PID}, 'LISTEN_PID cleaned');
+
+    # Make request using IO::Async::Stream to avoid blocking
+    my $resp_future = $loop->new_future;
+    my $response = '';
+
+    my $client_sock = IO::Socket::INET->new(
+        PeerAddr => '127.0.0.1',
+        PeerPort => $port,
+        Proto    => 'tcp',
+        Blocking => 0,
+    ) or die "Cannot connect: $!";
+
+    my $client_stream = IO::Async::Stream->new(
+        handle  => $client_sock,
+        on_read => sub {
+            my ($self, $buffref, $eof) = @_;
+            $response .= $$buffref;
+            $$buffref = '';
+            if ($eof) {
+                $resp_future->done($response);
+            }
+            return 0;
+        },
+    );
+    $loop->add($client_stream);
+    $client_stream->write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+
+    $response = $resp_future->get;
+
+    like($response, qr/200 OK/, 'got 200 from systemd socket');
+    like($response, qr/systemd activated/, 'got response body');
+
+    # Stream may already be auto-removed on EOF
+    $loop->remove($client_stream) if $client_stream->parent;
+    $server->shutdown->get;
+    $loop->remove($server);
+
+    # Close our socket at target_fd and restore whatever was there before
+    if ($orig_fd != $target_fd) {
+        POSIX::close($target_fd);
+        if (defined $saved_fd && $saved_fd >= 0) {
+            POSIX::dup2($saved_fd, $target_fd);
+            POSIX::close($saved_fd);
+        }
+    }
+    close($sd_socket);
+};
+
+subtest 'systemd: LISTEN_PID mismatch skips fds' => sub {
+    local $ENV{LISTEN_FDS} = '1';
+    local $ENV{LISTEN_PID} = '99999999';
+    local $ENV{PAGI_REUSE};
+
+    my $server = PAGI::Server->new(app => sub {}, quiet => 1, port => 0);
+    my $inherited = $server->_collect_inherited_fds;
+
+    is(scalar keys %$inherited, 0, 'no fds with PID mismatch');
+};
+
+done_testing;

--- a/t/50-hot-restart.t
+++ b/t/50-hot-restart.t
@@ -1,0 +1,293 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test2::V0;
+use POSIX ':sys_wait_h';
+use IO::Socket::INET;
+use File::Temp qw(tempdir);
+use File::Spec;
+use Cwd qw(abs_path);
+
+BEGIN { require FindBin; }
+
+plan skip_all => "Hot restart tests require RELEASE_TESTING"
+    unless $ENV{RELEASE_TESTING};
+plan skip_all => "Not supported on Windows" if $^O eq 'MSWin32';
+
+# Ensure the re-exec'd process can find our local lib/ code.
+# _hot_restart does fork+exec with $^X and $0, which does not preserve
+# perl's -Ilib flag. PERL5LIB is inherited across fork+exec.
+my $lib_dir = abs_path(File::Spec->catdir($FindBin::Bin, '..', 'lib'));
+$ENV{PERL5LIB} = join(':', grep { defined } $lib_dir, $ENV{PERL5LIB});
+
+my $bin = abs_path(File::Spec->catfile($FindBin::Bin, '..', 'bin', 'pagi-server'));
+
+# Prevent stray SIGTERMs from server shutdown from killing the test process.
+# Server shutdown can send TERM to process groups that include us.
+$SIG{TERM} = 'IGNORE';
+
+my @pids_to_cleanup;
+END {
+    for my $pid (@pids_to_cleanup) {
+        next unless $pid && kill(0, $pid);
+        kill('TERM', $pid);
+    }
+    # Give them a moment to exit
+    select(undef, undef, undef, 1) if @pids_to_cleanup;
+    for my $pid (@pids_to_cleanup) {
+        next unless $pid && kill(0, $pid);
+        kill('KILL', $pid);
+        waitpid($pid, WNOHANG);
+    }
+    # Reset $? so waitpid results don't leak into our exit code
+    $? = 0;
+}
+
+sub find_pids_on_port {
+    my ($port) = @_;
+    my @pids;
+    my $output = `lsof -ti tcp:$port -sTCP:LISTEN 2>/dev/null`;
+    if (defined $output) {
+        @pids = grep { $_ && $_ =~ /^\d+$/ } split /\n/, $output;
+    }
+    return @pids;
+}
+
+sub http_get {
+    my ($port, $timeout) = @_;
+    $timeout //= 5;
+    my $client = IO::Socket::INET->new(
+        PeerAddr => '127.0.0.1',
+        PeerPort => $port,
+        Proto    => 'tcp',
+        Timeout  => $timeout,
+    ) or return undef;
+    print $client "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    my $resp = '';
+    while (my $line = <$client>) { $resp .= $line; }
+    close $client;
+    return $resp;
+}
+
+sub wait_for_port {
+    my ($port, $timeout) = @_;
+    $timeout //= 10;
+    my $start = time();
+    while (time() - $start < $timeout) {
+        my $sock = IO::Socket::INET->new(
+            PeerAddr => '127.0.0.1',
+            PeerPort => $port,
+            Proto    => 'tcp',
+            Timeout  => 1,
+        );
+        if ($sock) {
+            close $sock;
+            return 1;
+        }
+        select(undef, undef, undef, 0.3);
+    }
+    return 0;
+}
+
+sub wait_for_exit {
+    my ($pid, $timeout) = @_;
+    $timeout //= 15;
+    my $start = time();
+    while (time() - $start < $timeout) {
+        # Use waitpid with WNOHANG to reap zombies and detect exit.
+        # kill(0) returns true for zombies, so we must actually reap.
+        my $ret = waitpid($pid, WNOHANG);
+        return 1 if $ret > 0;       # reaped, process exited
+        return 1 if $ret == -1;     # already reaped or doesn't exist
+        select(undef, undef, undef, 0.5);
+    }
+    return 0;
+}
+
+# Write a PAGI app that reports its PID in the response
+sub write_pid_app {
+    my ($dir) = @_;
+    my $app_file = File::Spec->catfile($dir, 'app.pl');
+    open my $fh, '>', $app_file or die "Cannot write $app_file: $!";
+    print $fh <<'APP';
+use strict;
+use warnings;
+use Future::AsyncAwait;
+
+my $app = async sub {
+    my ($scope, $receive, $send) = @_;
+
+    if ($scope->{type} eq 'lifespan') {
+        while (1) {
+            my $event = await $receive->();
+            if ($event->{type} eq 'lifespan.startup') {
+                await $send->({ type => 'lifespan.startup.complete' });
+            } elsif ($event->{type} eq 'lifespan.shutdown') {
+                await $send->({ type => 'lifespan.shutdown.complete' });
+                last;
+            }
+        }
+        return;
+    }
+
+    await $send->({
+        type    => 'http.response.start',
+        status  => 200,
+        headers => [['content-type', 'text/plain']],
+    });
+    await $send->({
+        type => 'http.response.body',
+        body => "pid=$$",
+        more => 0,
+    });
+};
+
+$app;
+APP
+    close $fh;
+    return $app_file;
+}
+
+subtest 'USR2 hot restart in multi-worker mode' => sub {
+    my $tmpdir = tempdir(CLEANUP => 1);
+    my $app_file = write_pid_app($tmpdir);
+    my $port = 40000 + int(rand(20000));
+
+    # Start the server in multi-worker mode
+    my $master_pid = fork();
+    die "fork failed: $!" unless defined $master_pid;
+
+    my $server_log = File::Spec->catfile($tmpdir, 'server.log');
+    if ($master_pid == 0) {
+        # Own process group so server signals don't reach the test process
+        setpgrp(0, 0);
+        # Redirect output to log file for post-mortem debugging
+        open STDOUT, '>', $server_log or POSIX::_exit(1);
+        open STDERR, '>&STDOUT' or POSIX::_exit(1);
+        exec($^X, '-Ilib', $bin,
+            '--host', '127.0.0.1',
+            '--port', $port,
+            '--workers', 2,
+            '--quiet',
+            '--heartbeat-timeout', 5,
+            '--no-default-middleware',
+            '--no-access-log',
+            $app_file,
+        ) or POSIX::_exit(1);
+    }
+
+    push @pids_to_cleanup, $master_pid;
+
+    # Wait for server to be ready
+    ok(wait_for_port($port, 15), "server started on port $port")
+        or do {
+            diag "Server did not start; killing master $master_pid";
+            kill('TERM', $master_pid);
+            return;
+        };
+
+    # Make a request to get a worker PID
+    my $resp1 = http_get($port);
+    ok(defined $resp1, 'got response before restart');
+    my ($pid_before) = ($resp1 // '') =~ /pid=(\d+)/;
+    ok(defined $pid_before, "extracted worker PID before restart: " . ($pid_before // 'none'));
+
+    # Send USR2 to trigger hot restart
+    kill('USR2', $master_pid);
+
+    # Wait for the restart to complete.
+    # handoff_delay = heartbeat_timeout/2 + 1 = 3.5s, plus worker startup time.
+    diag "Waiting for hot restart to complete...";
+    select(undef, undef, undef, 10);
+
+    # Verify the port is still accepting connections
+    ok(wait_for_port($port, 5), 'port still accepting connections after restart');
+
+    # Make another request to get the new worker PID
+    my $resp2 = http_get($port);
+    ok(defined $resp2, 'got response after restart');
+    my ($pid_after) = ($resp2 // '') =~ /pid=(\d+)/;
+    ok(defined $pid_after, "extracted worker PID after restart: " . ($pid_after // 'none'));
+
+    # The new workers should have different PIDs
+    if (defined $pid_before && defined $pid_after) {
+        isnt($pid_after, $pid_before, 'worker PID changed after hot restart');
+    }
+
+    # The old master should have been killed by the new master's handoff
+    ok(wait_for_exit($master_pid, 10), "old master $master_pid exited after handoff")
+        or do {
+            # Dump server log on failure to help diagnose
+            if (open my $log_fh, '<', $server_log) {
+                local $/;
+                diag "Server log:\n" . <$log_fh>;
+                close $log_fh;
+            }
+        };
+
+    # Clean up the new master and its workers
+    my @new_pids = find_pids_on_port($port);
+    for my $pid (@new_pids) {
+        next if $pid == $$;  # never kill ourselves
+        push @pids_to_cleanup, $pid;
+        kill('TERM', $pid);
+    }
+
+    # Wait for cleanup to take effect
+    select(undef, undef, undef, 2);
+};
+
+subtest 'USR2 in single-worker mode is ignored' => sub {
+    my $tmpdir = tempdir(CLEANUP => 1);
+    my $app_file = write_pid_app($tmpdir);
+    my $port = 40000 + int(rand(20000));
+
+    # Start single-worker server (no --workers flag)
+    my $server_pid = fork();
+    die "fork failed: $!" unless defined $server_pid;
+
+    if ($server_pid == 0) {
+        # Own process group so server signals don't reach the test process
+        setpgrp(0, 0);
+        exec($^X, '-Ilib', $bin,
+            '--host', '127.0.0.1',
+            '--port', $port,
+            '--quiet',
+            '--no-default-middleware',
+            '--no-access-log',
+            $app_file,
+        ) or POSIX::_exit(1);
+    }
+
+    push @pids_to_cleanup, $server_pid;
+
+    ok(wait_for_port($port, 15), "single-worker server started on port $port")
+        or do {
+            diag "Server did not start; killing $server_pid";
+            kill('TERM', $server_pid);
+            return;
+        };
+
+    # Verify it works before USR2
+    my $resp1 = http_get($port);
+    ok(defined $resp1, 'got response before USR2');
+    like($resp1, qr/200/, 'got 200 status before USR2');
+
+    # Send USR2 — should be ignored in single-worker mode
+    kill('USR2', $server_pid);
+
+    # Wait a moment for the signal to be processed
+    select(undef, undef, undef, 2);
+
+    # Verify server still works
+    ok(kill(0, $server_pid), 'server process still alive after USR2');
+
+    my $resp2 = http_get($port);
+    ok(defined $resp2, 'got response after USR2');
+    like($resp2, qr/200/, 'got 200 status after USR2');
+
+    # Clean up
+    kill('TERM', $server_pid);
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

- **PAGI_REUSE env var**: Mojo-inspired fd inheritance protocol. When PAGI creates a listening socket, it registers `addr:port:fd` (or `unix:path:fd`) in `$ENV{PAGI_REUSE}`. On restart, a new process reads the env var and reuses inherited fds instead of rebinding — enabling zero-downtime restarts.
- **`$^F = 1023` trick**: Prevents Perl's close-on-exec from closing listen socket fds during `exec()`, so fds survive hot restart re-exec.
- **systemd socket activation**: Auto-detects `LISTEN_FDS`/`LISTEN_PID`. Inherited fds are matched to configured listener specs by address (exact match on host:port or socket path). Same config works with or without systemd.
- **fd matching**: Before binding, both single-worker and multi-worker paths check for inherited fds. Matched fds are reused. Unmatched inherited fds are warned and closed. Unmatched specs bind normally.
- **Conditional shutdown cleanup**: Inherited Unix socket files are NOT unlinked on shutdown (the fd source owns them). PAGI_REUSE entries are preserved during hot restart.
- **PAGI_ARGV capture**: Original CLI args stored for future USR2 hot restart re-exec.

This is PR 1 of 2. PR 2 will add USR2 hot restart (fork+exec new master with fd inheritance).

## Test plan

- [ ] `prove -l t/48-fd-reuse.t` — 11 tests: PAGI_REUSE parsing (TCP, Unix, IPv6, multiple, malformed), fd matching integration, registration, cleanup, inherited socket preservation
- [ ] `prove -l t/49-systemd-activation.t` — 2 tests: simulated systemd socket activation via dup2+LISTEN_FDS, PID mismatch
- [ ] `prove -l t/43-unix-socket.t t/45-multi-listener.t` — existing tests still pass
- [ ] `RELEASE_TESTING=1 prove -l t/` — full suite, no new regressions
- [ ] Manual: set `PAGI_REUSE=127.0.0.1:5000:<fd>` and verify server reuses the socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)