### PR TITLE
docs: add PAGI::EventLoops (loop-agnostic apps, non-blocking I/O, server loop binding)

### DIFF
--- a/examples/14-periodic-events/README.md
+++ b/examples/14-periodic-events/README.md
@@ -1,0 +1,48 @@
+# 14 – Periodic Events
+
+An in-app event source built on `Future::IO`. A background loop produces a
+"tick" result every interval and delivers it to whoever is currently listening.
+This shows that you can model your own events as Futures and compose them with
+protocol events — without ever naming an event loop.
+
+The timer is a `Future::IO->sleep`, not an `IO::Async` timer, so the app does
+not assume any particular loop: it runs on whatever loop the server provides.
+
+## Routes
+
+- `GET /` – returns the current tick `count` immediately.
+- `GET /next` – *listens* for the next tick (long-poll). It pushes a fresh
+  `Future` onto the waiter list and awaits it; the background source resolves
+  that Future on the next tick. The await is non-blocking, so other requests
+  are served while this one waits.
+
+## Quick Start
+
+**1. Start the server:**
+
+```bash
+# Installed server:
+pagi-server --app examples/14-periodic-events/app.pl --port 5014
+
+# Or run against an uninstalled checkout of PAGI-Server:
+perl -I ~/Desktop/PAGI-Server/lib ~/Desktop/PAGI-Server/bin/pagi-server \
+  --app examples/14-periodic-events/app.pl --port 5014
+```
+
+**2. Demo with curl:**
+
+```bash
+curl -s localhost:5014/ ; echo
+# => {"count":3,"hint":"GET /next to wait for the next tick"}
+
+time curl -s localhost:5014/next ; echo
+# => {"tick":4,"at":1781893422}   (blocks up to ~2s, then wakes on the tick)
+
+curl -s localhost:5014/ ; echo
+# => {"count":4,...}   (count advanced while you waited)
+```
+
+## Spec References
+
+- Defining your own events – `PAGI::Spec::Extensions` ("Defining your own events")
+- Loop-agnostic timing and event sources – `PAGI::EventLoops`

--- a/examples/14-periodic-events/README.md
+++ b/examples/14-periodic-events/README.md
@@ -21,11 +21,13 @@ not assume any particular loop: it runs on whatever loop the server provides.
 **1. Start the server:**
 
 ```bash
-# Installed server:
 pagi-server --app examples/14-periodic-events/app.pl --port 5014
+```
 
-# Or run against an uninstalled checkout of PAGI-Server:
-perl -I ~/Desktop/PAGI-Server/lib ~/Desktop/PAGI-Server/bin/pagi-server \
+From an uninstalled PAGI-Server checkout, add `-I /path/to/PAGI-Server/lib`:
+
+```bash
+perl -I /path/to/PAGI-Server/lib /path/to/PAGI-Server/bin/pagi-server \
   --app examples/14-periodic-events/app.pl --port 5014
 ```
 

--- a/examples/14-periodic-events/README.md
+++ b/examples/14-periodic-events/README.md
@@ -1,20 +1,36 @@
 # 14 – Periodic Events
 
-An in-app event source built on `Future::IO`. A background loop produces a
-"tick" result every interval and delivers it to whoever is currently listening.
-This shows that you can model your own events as Futures and compose them with
-protocol events — without ever naming an event loop.
+A periodic background event source, **rooted in the lifespan scope**. Every
+interval the source produces a "tick" and delivers it to whoever is currently
+listening. It shows how to model your own events as Futures and run long-lived
+background work correctly — without ever naming an event loop.
 
-The timer is a `Future::IO->sleep`, not an `IO::Async` timer, so the app does
-not assume any particular loop: it runs on whatever loop the server provides.
+The key idea: an event-driven app is a **tree of futures**. The source lives in
+a `Future::Selector` held by the lifespan handler, which the server keeps alive
+for the whole life of the app — so it is a real branch of the tree. Nothing is
+pinned in a file-scoped variable, so nothing is silently dropped, and because the
+selector propagates failures, a crashing source surfaces (the server logs it)
+rather than vanishing.
+
+> **Anti-pattern, for contrast:** starting the source at file scope and keeping
+> it alive in an `our` (or a bare `my`, which is worse — it is garbage-collected
+> as soon as the app file finishes loading, dying with a cryptic *"lost its
+> returning future"* warning). That is a future with no parent in the tree. Give
+> it a parent instead: the lifespan scope.
+
+The timer is a `Future::IO->sleep`, not an `IO::Async` timer, so the app does not
+assume any particular loop.
 
 ## Routes
 
 - `GET /` – returns the current tick `count` immediately.
 - `GET /next` – *listens* for the next tick (long-poll). It pushes a fresh
   `Future` onto the waiter list and awaits it; the background source resolves
-  that Future on the next tick. The await is non-blocking, so other requests
-  are served while this one waits.
+  that Future on the next tick. The await is non-blocking, so other requests are
+  served while this one waits.
+
+State (`count`, the waiter list) lives in `$scope->{state}`, which the lifespan
+handler seeds and every request scope can read.
 
 ## Quick Start
 
@@ -35,16 +51,17 @@ perl -I /path/to/PAGI-Server/lib /path/to/PAGI-Server/bin/pagi-server \
 
 ```bash
 curl -s localhost:5014/ ; echo
-# => {"count":3,"hint":"GET /next to wait for the next tick"}
+# => {"count":1,"hint":"GET /next to wait for the next tick"}
 
 time curl -s localhost:5014/next ; echo
-# => {"tick":4,"at":1781893422}   (blocks up to ~2s, then wakes on the tick)
+# => {"tick":2}   (blocks up to ~2s, then wakes on the next tick)
 
 curl -s localhost:5014/ ; echo
-# => {"count":4,...}   (count advanced while you waited)
+# => {"count":2,...}   (count advanced while you waited)
 ```
 
 ## Spec References
 
+- Writing your own event source – `PAGI::EventLoops` (the chain/tree-of-futures section)
+- Lifespan scope and shared state – `PAGI::Spec::Lifespan`
 - Defining your own events – `PAGI::Spec::Extensions` ("Defining your own events")
-- Loop-agnostic timing and event sources – `PAGI::EventLoops`

--- a/examples/14-periodic-events/app.pl
+++ b/examples/14-periodic-events/app.pl
@@ -1,0 +1,67 @@
+use strict;
+use warnings;
+use Future::AsyncAwait;
+use Future::IO;
+use JSON::PP ();
+
+# Keep this example's package-level state (the ticker future, below) out of
+# main::, which is shared with the server and any other loaded app file.
+package PeriodicEvents;
+
+# --- In-app event source -------------------------------------------------
+# Every $INTERVAL seconds, produce a result and deliver it to whoever is
+# currently listening. The timer is a Future::IO->sleep, so this names no
+# event loop: it runs on whatever loop the server is using.
+my $INTERVAL = 2;
+my $count    = 0;
+my @waiters;   # Futures awaiting the next tick
+
+# Keep the source future in a package variable so it is not garbage-collected
+# when the app file finishes loading (package variables outlive the do-file scope).
+our $TICKER = (async sub {
+    while (1) {
+        await Future::IO->sleep($INTERVAL);
+        $count++;
+        my $result = { tick => $count, at => time };
+        my @pending = @waiters;
+        @waiters = ();
+        $_->done($result) for @pending;
+    }
+})->();
+$TICKER->on_fail(sub { warn "periodic source failed: $_[0]\n" });
+
+# --- The PAGI application ------------------------------------------------
+my $app = async sub {
+    my ($scope, $receive, $send) = @_;
+
+    # Only handle HTTP. Other scopes (e.g. lifespan) reach the app too; decline
+    # them rather than sending an HTTP response into the wrong protocol.
+    return unless ($scope->{type} // '') eq 'http';
+
+    if ($scope->{path} eq '/next') {
+        # "Listen" for the next event: await a Future the source resolves.
+        # Non-blocking -- other requests are served while this one waits.
+        my $f = Future->new;
+        push @waiters, $f;
+        await reply($send, 200, await $f);
+    }
+    else {
+        await reply($send, 200,
+            { count => $count, hint => 'GET /next to wait for the next tick' });
+    }
+};
+
+async sub reply {
+    my ($send, $status, $data) = @_;
+    await $send->({
+        type    => 'http.response.start',
+        status  => $status,
+        headers => [ ['content-type', 'application/json'] ],
+    });
+    await $send->({
+        type => 'http.response.body',
+        body => JSON::PP::encode_json($data),
+    });
+}
+
+$app;

--- a/examples/14-periodic-events/app.pl
+++ b/examples/14-periodic-events/app.pl
@@ -34,9 +34,10 @@ $TICKER->on_fail(sub { warn "periodic source failed: $_[0]\n" });
 my $app = async sub {
     my ($scope, $receive, $send) = @_;
 
-    # Only handle HTTP. Other scopes (e.g. lifespan) reach the app too; decline
-    # them rather than sending an HTTP response into the wrong protocol.
-    return unless ($scope->{type} // '') eq 'http';
+    # Decline any non-HTTP scope (e.g. lifespan) by raising -- a PAGI app signals
+    # "I don't handle this scope" with an exception, not a bare return. The server
+    # treats a raise on the lifespan scope as "lifespan unsupported" and continues.
+    die "Unsupported scope type: $scope->{type}" if $scope->{type} ne 'http';
 
     if ($scope->{path} eq '/next') {
         # "Listen" for the next event: await a Future the source resolves.

--- a/examples/14-periodic-events/app.pl
+++ b/examples/14-periodic-events/app.pl
@@ -2,55 +2,95 @@ use strict;
 use warnings;
 use Future::AsyncAwait;
 use Future::IO;
+use Future::Selector;
 use JSON::PP ();
 
-# Keep this example's package-level state (the ticker future, below) out of
-# main::, which is shared with the server and any other loaded app file.
-package PeriodicEvents;
+# A periodic background event source, rooted in the lifespan scope.
+#
+# An event-driven app is a TREE of futures. Long-lived background work belongs
+# on a branch of that tree -- here, a Future::Selector held in the lifespan
+# handler's frame, which the server keeps alive for the whole life of the app.
+# Nothing is held in a file-scoped variable, so nothing is silently dropped, and
+# because the selector propagates failures, a crashing source surfaces (the
+# server logs it) instead of vanishing.
+#
+# Anti-pattern, for contrast: starting the source at file scope and pinning it in
+# an `our` (or a bare `my`, which is worse -- it is garbage-collected the moment
+# the app file finishes loading and dies with a cryptic "lost its returning
+# future" warning). That is a future with no parent in the tree. Give it a parent
+# instead: the lifespan scope.
 
-# --- In-app event source -------------------------------------------------
-# Every $INTERVAL seconds, produce a result and deliver it to whoever is
-# currently listening. The timer is a Future::IO->sleep, so this names no
-# event loop: it runs on whatever loop the server is using.
-my $INTERVAL = 2;
-my $count    = 0;
-my @waiters;   # Futures awaiting the next tick
-
-# Keep the source future in a package variable so it is not garbage-collected
-# when the app file finishes loading (package variables outlive the do-file scope).
-our $TICKER = (async sub {
-    while (1) {
-        await Future::IO->sleep($INTERVAL);
-        $count++;
-        my $result = { tick => $count, at => time };
-        my @pending = @waiters;
-        @waiters = ();
-        $_->done($result) for @pending;
-    }
-})->();
-$TICKER->on_fail(sub { warn "periodic source failed: $_[0]\n" });
-
-# --- The PAGI application ------------------------------------------------
-my $app = async sub {
+async sub handle_lifespan {
     my ($scope, $receive, $send) = @_;
 
-    # Decline any non-HTTP scope (e.g. lifespan) by raising -- a PAGI app signals
-    # "I don't handle this scope" with an exception, not a bare return. The server
-    # treats a raise on the lifespan scope as "lifespan unsupported" and continues.
-    die "Unsupported scope type: $scope->{type}" if $scope->{type} ne 'http';
+    # Shared state, visible to every request scope via $scope->{state}.
+    my $state = $scope->{state} //= {};
+    $state->{count}   = 0;
+    $state->{waiters} = [];
 
-    if ($scope->{path} eq '/next') {
-        # "Listen" for the next event: await a Future the source resolves.
+    # Wait for startup, then announce we are ready.
+    while (1) {
+        my $event = await $receive->();
+        last if $event->{type} eq 'lifespan.startup';
+    }
+    await $send->({ type => 'lifespan.startup.complete' });
+
+    # The event source: every $INTERVAL seconds produce a tick and deliver it to
+    # anyone currently listening on /next. The Future::IO->sleep names no event
+    # loop -- it runs on whatever loop the server uses. The selector holds the
+    # source's futures, so it is retained without any `our`.
+    my $INTERVAL = 2;
+    my $selector = Future::Selector->new;
+    $selector->add(
+        data => 'ticker',
+        gen  => async sub {
+            await Future::IO->sleep($INTERVAL);
+            $state->{count}++;
+            my $waiters = $state->{waiters};
+            $state->{waiters} = [];
+            $_->done($state->{count}) for @$waiters;
+            return;
+        },
+    );
+
+    # Run the source until shutdown. wait_any resolves when shutdown arrives
+    # (cancelling the selector); if a source fails, wait_any fails and the error
+    # propagates out of this handler for the server to log.
+    my $shutdown = (async sub {
+        while (1) {
+            my $event = await $receive->();
+            return if $event->{type} eq 'lifespan.shutdown';
+        }
+    })->();
+    await Future->wait_any($shutdown, $selector->run);
+
+    await $send->({ type => 'lifespan.shutdown.complete' });
+}
+
+async sub handle_http {
+    my ($scope, $receive, $send) = @_;
+
+    my $state = $scope->{state} // {};
+
+    # Drain the request body.
+    while (1) {
+        my $event = await $receive->();
+        last if $event->{type} ne 'http.request';
+        last unless $event->{more};
+    }
+
+    if (($scope->{path} // '/') eq '/next') {
+        # "Listen" for the next tick: register a Future the source resolves.
         # Non-blocking -- other requests are served while this one waits.
         my $f = Future->new;
-        push @waiters, $f;
-        await reply($send, 200, await $f);
+        push @{ $state->{waiters} }, $f;
+        await reply($send, 200, { tick => await $f });
     }
     else {
         await reply($send, 200,
-            { count => $count, hint => 'GET /next to wait for the next tick' });
+            { count => $state->{count} // 0, hint => 'GET /next to wait for the next tick' });
     }
-};
+}
 
 async sub reply {
     my ($send, $status, $data) = @_;
@@ -62,7 +102,18 @@ async sub reply {
     await $send->({
         type => 'http.response.body',
         body => JSON::PP::encode_json($data),
+        more => 0,
     });
 }
+
+my $app = async sub {
+    my ($scope, $receive, $send) = @_;
+
+    return await handle_lifespan($scope, $receive, $send) if $scope->{type} eq 'lifespan';
+    return await handle_http($scope, $receive, $send)     if $scope->{type} eq 'http';
+
+    # Decline any other scope by raising -- the canonical PAGI idiom.
+    die "Unsupported scope type: $scope->{type}";
+};
 
 $app;

--- a/examples/14-periodic-events/cpanfile
+++ b/examples/14-periodic-events/cpanfile
@@ -3,5 +3,6 @@
 requires 'perl', '5.018';
 requires 'Future::AsyncAwait';
 requires 'Future::IO';
-requires 'PAGI::Server';   # the reference server (provides pagi-server)
+requires 'Future::Selector';   # holds the background source on a branch of the future tree
+requires 'PAGI::Server';       # the reference server (provides pagi-server)
 # JSON::PP is core.

--- a/examples/14-periodic-events/cpanfile
+++ b/examples/14-periodic-events/cpanfile
@@ -1,0 +1,7 @@
+# Run this example with the reference server:
+#   pagi-server app.pl --port 5014
+requires 'perl', '5.018';
+requires 'Future::AsyncAwait';
+requires 'Future::IO';
+requires 'PAGI::Server';   # the reference server (provides pagi-server)
+# JSON::PP is core.

--- a/examples/15-embedded-ioasync/README.md
+++ b/examples/15-embedded-ioasync/README.md
@@ -32,11 +32,13 @@ so you know the server is ready before the host app prints its "listening" line.
 **1. Start the server:**
 
 ```bash
-# Against an uninstalled checkout of PAGI-Server:
-perl -I ~/Desktop/PAGI-Server/lib examples/15-embedded-ioasync/server.pl
-
-# Against an installed PAGI::Server:
 perl examples/15-embedded-ioasync/server.pl
+```
+
+From an uninstalled PAGI-Server checkout, add `-I /path/to/PAGI-Server/lib`:
+
+```bash
+perl -I /path/to/PAGI-Server/lib examples/15-embedded-ioasync/server.pl
 ```
 
 **2. Demo with curl:**

--- a/examples/15-embedded-ioasync/README.md
+++ b/examples/15-embedded-ioasync/README.md
@@ -1,0 +1,57 @@
+# 15 – Embedded IO::Async
+
+Demonstrates **embedding `PAGI::Server` inside a larger IO::Async program** (the
+"D1" pattern from `PAGI::EventLoops`). The caller owns the loop, runs its own
+periodic activity on the same loop, and hands the server in via
+`$loop->add` / `listen->get` / `$loop->run`.
+
+Because there is no `pagi-server` wrapper, **the embedder must wire the
+`Future::IO` backend** with `use Future::IO::Impl::IOAsync` — the server cannot
+do it for you.
+
+## Owning vs. Embedding
+
+| Mode | Who creates the loop? | Who calls `$loop->run`? | Future::IO wiring |
+|------|-----------------------|-------------------------|--------------------|
+| `pagi-server` (owning) | The server | The server | Automatic |
+| Embedded (this example) | **Your program** | **Your program** | `use Future::IO::Impl::IOAsync` |
+
+The embedding pattern is three lines:
+
+```perl
+$loop->add($server);   # register the server as an IO::Async::Notifier
+$server->listen->get;  # bind the port (no loop iteration needed yet)
+$loop->run;            # your program drives the loop
+```
+
+`listen->get` binds the port synchronously via `get` on the returned Future,
+so you know the server is ready before the host app prints its "listening" line.
+
+## Quick Start
+
+**1. Start the server:**
+
+```bash
+# Against an uninstalled checkout of PAGI-Server:
+perl -I ~/Desktop/PAGI-Server/lib examples/15-embedded-ioasync/server.pl
+
+# Against an installed PAGI::Server:
+perl examples/15-embedded-ioasync/server.pl
+```
+
+**2. Demo with curl:**
+
+```bash
+curl -s localhost:5015/ ; echo
+# => Hello from a PAGI::Server embedded in an IO::Async app
+```
+
+While the server runs you should see `[host app] tick at ...` warnings on
+stderr every 2 seconds — before the request, during it, and after — confirming
+that the host-app timer and the HTTP server share the same event loop without
+interfering.
+
+## Spec References
+
+- Embedding pattern (D1) – `PAGI::EventLoops`
+- `PAGI::Server` loop integration – `PAGI::Server` / `LOOP INTEROPERABILITY`

--- a/examples/15-embedded-ioasync/cpanfile
+++ b/examples/15-embedded-ioasync/cpanfile
@@ -1,0 +1,6 @@
+# Run: perl server.pl   (then curl localhost:5015)
+requires 'perl', '5.018';
+requires 'IO::Async';
+requires 'Future::AsyncAwait';
+requires 'Future::IO';
+requires 'PAGI::Server';

--- a/examples/15-embedded-ioasync/server.pl
+++ b/examples/15-embedded-ioasync/server.pl
@@ -8,7 +8,7 @@ use PAGI::Server;
 
 my $app = async sub {
     my ($scope, $receive, $send) = @_;
-    return unless ($scope->{type} // '') eq 'http';
+    die "Unsupported scope type: $scope->{type}" if $scope->{type} ne 'http';
     await $send->({
         type    => 'http.response.start',
         status  => 200,

--- a/examples/15-embedded-ioasync/server.pl
+++ b/examples/15-embedded-ioasync/server.pl
@@ -1,0 +1,37 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use IO::Async::Loop;
+use Future::IO::Impl::IOAsync;   # we embed, so WE wire the Future::IO backend
+use Future::AsyncAwait;
+use PAGI::Server;
+
+my $app = async sub {
+    my ($scope, $receive, $send) = @_;
+    return unless ($scope->{type} // '') eq 'http';
+    await $send->({
+        type    => 'http.response.start',
+        status  => 200,
+        headers => [ ['content-type', 'text/plain'] ],
+    });
+    await $send->({
+        type => 'http.response.body',
+        body => "Hello from a PAGI::Server embedded in an IO::Async app\n",
+    });
+};
+
+my $loop = IO::Async::Loop->new;
+
+# Host-app activity sharing the SAME loop, to prove cohabitation.
+my $tick;
+$tick = sub {
+    warn "[host app] tick at " . time . "\n";
+    $loop->watch_time(after => 2, code => $tick);
+};
+$loop->watch_time(after => 2, code => $tick);
+
+my $server = PAGI::Server->new(app => $app, port => 5015);
+$loop->add($server);
+$server->listen->get;     # listen without running the loop
+print "embedded PAGI::Server listening on http://localhost:5015\n";
+$loop->run;               # the host app owns the loop

--- a/examples/16-foreign-loop/README.md
+++ b/examples/16-foreign-loop/README.md
@@ -1,0 +1,67 @@
+# Example 16 — PAGI::Server under a Foreign (EV-backed) Loop
+
+Demonstrates running `PAGI::Server` under an **EV**-backed `IO::Async` loop,
+and verifies that `Future::IO` operations actually tick on that loop.
+
+## The diagnostic
+
+The HTTP handler does `await Future::IO->sleep(1)` **before** sending a
+response. If the response arrives after ~1 second, `Future::IO` is correctly
+driven by the EV loop. If the request hangs, it is not.
+
+## How the wiring works
+
+```perl
+BEGIN { $ENV{IO_ASYNC_LOOP} = 'EV' }   # (1) select the EV backend globally
+use IO::Async::Loop;
+use Future::IO::Impl::IOAsync;          # (2) wire Future::IO to IO::Async
+use PAGI::Server;
+
+my $loop   = IO::Async::Loop->new;      # IO::Async::Loop::EV
+my $server = PAGI::Server->new(app => $app, port => 5016);
+$loop->add($server);
+$server->listen->get;   # bind without starting the loop
+$loop->run;             # the host app owns the loop
+```
+
+Three things must be in place:
+
+1. **`IO_ASYNC_LOOP=EV` (or `BEGIN` block)** — `IO::Async::Loop->new` reads
+   this env var and constructs `IO::Async::Loop::EV` instead of the default
+   poll/epoll backend.
+2. **`Future::IO::Impl::IOAsync`** — loaded by the embedder, this routes all
+   `Future::IO` calls (including `Future::IO->sleep`) through the shared
+   IO::Async loop, which is now EV-backed.
+3. **`$loop->add($server)` before `$server->listen->get`** — `PAGI::Server`
+   is an `IO::Async::Notifier`; it must be added to the loop before it binds.
+
+## Observed outcome (SUCCESS)
+
+```
+loop backend: IO::Async::Loop::EV
+PAGI Server listening on http://127.0.0.1:5016/ (loop: EV, ...)
+```
+
+```
+$ time curl -s localhost:5016/
+PAGI::Server is running under the EV loop; Future::IO ticked
+
+real    0m1.019s
+```
+
+Response arrived in ~1.019 s — the `Future::IO->sleep(1)` resolved correctly
+on the EV-backed loop. Both server I/O and `Future::IO` are driven by EV.
+
+## Running
+
+```bash
+perl -I /path/to/PAGI-Server/lib server.pl
+# In another terminal:
+curl localhost:5016/
+```
+
+## See also
+
+- `PAGI::EventLoops` — full embedding guide (D2 section covers EV integration)
+- Example 15 (`examples/15-embedded-ioasync/`) — embedding without a foreign
+  event loop (plain IO::Async default backend)

--- a/examples/16-foreign-loop/README.md
+++ b/examples/16-foreign-loop/README.md
@@ -55,9 +55,15 @@ on the EV-backed loop. Both server I/O and `Future::IO` are driven by EV.
 ## Running
 
 ```bash
-perl -I /path/to/PAGI-Server/lib server.pl
+perl examples/16-foreign-loop/server.pl
 # In another terminal:
 curl localhost:5016/
+```
+
+From an uninstalled PAGI-Server checkout, add `-I /path/to/PAGI-Server/lib`:
+
+```bash
+perl -I /path/to/PAGI-Server/lib examples/16-foreign-loop/server.pl
 ```
 
 ## See also

--- a/examples/16-foreign-loop/cpanfile
+++ b/examples/16-foreign-loop/cpanfile
@@ -1,0 +1,8 @@
+# Run: perl server.pl   (then curl localhost:5016)
+requires 'perl', '5.018';
+requires 'IO::Async';
+requires 'IO::Async::Loop::EV';
+requires 'EV';
+requires 'Future::AsyncAwait';
+requires 'Future::IO';
+requires 'PAGI::Server';

--- a/examples/16-foreign-loop/server.pl
+++ b/examples/16-foreign-loop/server.pl
@@ -12,7 +12,7 @@ use PAGI::Server;
 
 my $app = async sub {
     my ($scope, $receive, $send) = @_;
-    return unless ($scope->{type} // '') eq 'http';
+    die "Unsupported scope type: $scope->{type}" if $scope->{type} ne 'http';
     # Exercise Future::IO under the foreign loop: if this resolves, Future::IO
     # is ticking on the EV loop. If the request hangs here, it is not.
     await Future::IO->sleep(1);

--- a/examples/16-foreign-loop/server.pl
+++ b/examples/16-foreign-loop/server.pl
@@ -1,0 +1,37 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+# Force IO::Async onto the EV backend for EVERY IO::Async::Loop->new call
+# (the server, and Future::IO's impl, must share one EV-backed loop).
+BEGIN { $ENV{IO_ASYNC_LOOP} = 'EV' }
+use IO::Async::Loop;
+use Future::IO;
+use Future::IO::Impl::IOAsync;   # embedder wires the Future::IO backend
+use Future::AsyncAwait;
+use PAGI::Server;
+
+my $app = async sub {
+    my ($scope, $receive, $send) = @_;
+    return unless ($scope->{type} // '') eq 'http';
+    # Exercise Future::IO under the foreign loop: if this resolves, Future::IO
+    # is ticking on the EV loop. If the request hangs here, it is not.
+    await Future::IO->sleep(1);
+    await $send->({
+        type    => 'http.response.start',
+        status  => 200,
+        headers => [ ['content-type', 'text/plain'] ],
+    });
+    await $send->({
+        type => 'http.response.body',
+        body => "PAGI::Server is running under the EV loop; Future::IO ticked\n",
+    });
+};
+
+my $loop = IO::Async::Loop->new;   # EV-backed (per IO_ASYNC_LOOP above)
+warn "loop backend: " . ref($loop) . "\n";
+
+my $server = PAGI::Server->new(app => $app, port => 5016);
+$loop->add($server);
+$server->listen->get;
+print "PAGI::Server running under EV on http://localhost:5016\n";
+$loop->run;

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,6 +34,15 @@ and L<PAGI::Spec>.
 9. `11-job-runner` - background job processing (uses `IO::Async` directly for timers/subprocesses)
 10. `12-utf8` - UTF-8 handling demonstration
 11. `13-flow-control` - conflation under backpressure via the `pagi.transport` handle
+12. `14-periodic-events` - an in-app periodic event source (Future::IO timer) with a long-poll listener
+
+## Embedding & event loops
+
+- `15-embedded-ioasync` - embed `PAGI::Server` in a larger IO::Async program (caller owns the loop)
+- `16-foreign-loop` - run `PAGI::Server` under an EV-backed IO::Async loop
+
+For the full story -- loop-agnostic apps, non-blocking I/O, and binding a
+server to a loop -- see L<PAGI::EventLoops>.
 
 ## More examples
 

--- a/examples/mini-framework/app.pl
+++ b/examples/mini-framework/app.pl
@@ -53,7 +53,7 @@ package Nano {
         my ($self) = @_;
         return async sub {
             my ($scope, $receive, $send) = @_;
-            return unless $scope->{type} eq 'http';
+            die "Unsupported scope type: $scope->{type}" if $scope->{type} ne 'http';
 
             for my $route (@{ $self->{routes} }) {
                 next unless $route->{method} eq $scope->{method};

--- a/lib/PAGI/Building.pod
+++ b/lib/PAGI/Building.pod
@@ -169,6 +169,8 @@ part of what turns "a few conveniences" into a framework people trust.
 
 =item L<PAGI::Spec::Extensions> - the extension mechanism and custom events
 
+=item L<PAGI::EventLoops> - event loops, non-blocking I/O, and binding a server to a loop
+
 =back
 
 And F<examples/mini-framework> for a complete framework in about fifty lines.

--- a/lib/PAGI/Cookbook.pod
+++ b/lib/PAGI/Cookbook.pod
@@ -646,6 +646,10 @@ L<PAGI> - the specification overview and ecosystem map
 
 L<PAGI::Spec> - the formal specification
 
+=item *
+
+L<PAGI::EventLoops> - event loops, non-blocking I/O, and binding a server to a loop
+
 =back
 
 =head1 AUTHOR

--- a/lib/PAGI/EventLoops.pod
+++ b/lib/PAGI/EventLoops.pod
@@ -100,7 +100,7 @@ Future::IO backend> below).
 
     my $app = async sub {
         my ($scope, $receive, $send) = @_;
-        return unless ($scope->{type} // '') eq 'http';
+        die "Unsupported scope type: $scope->{type}" if $scope->{type} ne 'http';
 
         # Non-blocking pause: the loop keeps serving other clients meanwhile.
         await Future::IO->sleep(1);
@@ -217,7 +217,7 @@ request -- nothing is blocked:
 
     my $app = async sub {
         my ($scope, $receive, $send) = @_;
-        return unless ($scope->{type} // '') eq 'http';
+        die "Unsupported scope type: $scope->{type}" if $scope->{type} ne 'http';
 
         if ($scope->{path} eq '/next') {
             my $f = Future->new;

--- a/lib/PAGI/EventLoops.pod
+++ b/lib/PAGI/EventLoops.pod
@@ -12,6 +12,11 @@ loop-neutral: it suspends on a Future, and I<which loop resumes it> depends only
 on what created the leaf Future you awaited. So the loop never enters through
 your control flow -- only through the I/O primitives you call.
 
+Compose those awaits and the whole application becomes a B<tree of futures> --
+chains where work is sequential, branches where it runs concurrently -- and the
+loop's only job is to turn the root. That picture is the through-line here, and it
+is what makes background work (part three) correct rather than a footgun.
+
 A PAGI app B<must not assume IO::Async, or any loop, is already set up.>
 L<PAGI::Server> is the I<reference> implementation, not I<the> implementation;
 other servers are expected, and your app should run unchanged on any of them.
@@ -179,82 +184,108 @@ server cooperation -- the source is just ordinary Future plumbing inside your
 program. (See L<PAGI::Spec::Extensions/"Defining your own events"> for where
 this sits in the extension model.)
 
-A worked example: a background ticker that fires every couple of seconds, plus a
-long-poll endpoint that lets a client wait for the next tick. The runnable
-version is F<examples/14-periodic-events>; the teaching essentials follow.
+=head2 An app is a tree of futures
 
-First, keep the source out of C<main::> and give it its own package. The reason
-is not cosmetic -- see the lifetime note below.
+Think of an event-driven application as a single B<tree of futures>. A linear
+C<await> sequence is a chain; concurrent work B<branches> -- a node awaits several
+children at once. The event loop's only job is to turn the root; everything else
+is a child held by its parent.
 
-    package PeriodicEvents;
+This frame is what makes background work correct. A long-lived source -- a ticker,
+a queue listener, a health probe -- is a B<branch> of the tree, and it must have a
+parent that holds it. A future with no parent is an orphan, and an orphan is
+exactly the "lost its returning future" footgun (see below). In a raw PAGI app the
+natural parent for app-lifetime work is the B<lifespan scope>: the lifespan
+handler is invoked once and stays suspended for the whole life of the app, so the
+server holds it -- and anything it holds -- until shutdown.
 
-    use Future::AsyncAwait;
-    use Future::IO;
+=head2 A periodic source, rooted in lifespan
 
-    my $INTERVAL = 2;
-    my $count    = 0;
-    my @waiters;   # Futures awaiting the next tick
+A worked example: a ticker that fires every couple of seconds, plus a long-poll
+endpoint that lets a client wait for the next tick. The runnable version is
+F<examples/14-periodic-events>; the essentials follow.
 
-The source itself is an async loop whose only timer is a C<Future::IO-E<gt>sleep>,
-so it names no event loop -- it runs on whatever loop the server is using. Each
-tick resolves every Future currently waiting:
+Start the source in the lifespan handler and hold it in a L<Future::Selector> -- a
+container that keeps a set of pending futures alive and propagates their failures.
+Because the selector lives in the lifespan handler's frame, and the server holds
+that handler, the source is retained for the app's lifetime with B<no file-scoped
+variables>. Shared state lives in C<< $scope->{state} >>, which every request
+scope can read:
 
-    our $TICKER = (async sub {
-        while (1) {
-            await Future::IO->sleep($INTERVAL);
-            $count++;
-            my $result = { tick => $count, at => time };
-            my @pending = @waiters;
-            @waiters = ();
-            $_->done($result) for @pending;
-        }
-    })->();
-    $TICKER->on_fail(sub { warn "periodic source failed: $_[0]\n" });
-
-The handler "listens" for the next event by creating a Future, pushing it onto
-the waiter list, and awaiting it. While it waits, the loop serves every other
-request -- nothing is blocked:
-
-    my $app = async sub {
+    async sub handle_lifespan {
         my ($scope, $receive, $send) = @_;
-        die "Unsupported scope type: $scope->{type}" if $scope->{type} ne 'http';
+        my $state = $scope->{state} //= { count => 0, waiters => [] };
 
-        if ($scope->{path} eq '/next') {
+        while (1) { last if (await $receive->())->{type} eq 'lifespan.startup' }
+        await $send->({ type => 'lifespan.startup.complete' });
+
+        my $selector = Future::Selector->new;
+        $selector->add(data => 'ticker', gen => async sub {
+            await Future::IO->sleep(2);          # a Future::IO timer names no loop
+            $state->{count}++;
+            my $waiters = $state->{waiters};
+            $state->{waiters} = [];
+            $_->done($state->{count}) for @$waiters;
+            return;
+        });
+
+        # Run the source until shutdown. If a source fails, run() fails and the
+        # error propagates out of this handler for the server to log -- it does
+        # not vanish.
+        my $shutdown = (async sub {
+            while (1) { return if (await $receive->())->{type} eq 'lifespan.shutdown' }
+        })->();
+        await Future->wait_any($shutdown, $selector->run);
+
+        await $send->({ type => 'lifespan.shutdown.complete' });
+    }
+
+The HTTP handler "listens" for the next tick by creating a Future, registering it,
+and awaiting it. While it waits, the loop serves every other request:
+
+    async sub handle_http {
+        my ($scope, $receive, $send) = @_;
+        my $state = $scope->{state};
+        # ... drain the request body ...
+
+        if (($scope->{path} // '/') eq '/next') {
             my $f = Future->new;
-            push @waiters, $f;
-            await reply($send, 200, await $f);
+            push @{ $state->{waiters} }, $f;
+            await reply($send, 200, { tick => await $f });    # wakes on the next tick
         }
         else {
-            await reply($send, 200,
-                { count => $count, hint => 'GET /next to wait for the next tick' });
+            await reply($send, 200, { count => $state->{count} });
         }
-    };
+    }
 
-(C<reply> is a small JSON-response helper; the full runnable version is in
-F<examples/14-periodic-events>.)
+That is the whole pattern: a source on a branch of the tree resolving Futures, and
+a handler that awaits them. It composes with C<$receive> through ordinary Future
+combinators -- C<Future-E<gt>wait_any($receive-E<gt>(), $my_event)> waits on a
+client message or your own event, whichever arrives first.
 
-This is the whole pattern: a source that resolves Futures, and a handler that
-awaits them. It composes with C<$receive> through ordinary Future combinators --
-C<Future-E<gt>wait_any($receive-E<gt>(), $my_event)> waits on a client message
-or your own event, whichever arrives first.
+=head2 A lifetime footgun: orphaned futures
 
-=head2 A lifetime footgun
-
-The C<our $TICKER> above is not a style choice -- it is load-bearing. A
-background task whose Future is held only in a file-scoped C<my> is garbage
-collected once the app finishes loading. Under C<pagi-server> the app is loaded
-with C<do $file>, which returns the C<$app> closure; that closure does not close
-over a file-scoped C<my $ticker>, so the only reference to the running task goes
-out of scope and the task is silently destroyed. The sole symptom is a cryptic
+If you skip the tree and start a background task at file scope, you get a future
+with no parent -- and Perl reaps it. Under C<pagi-server> the app is loaded with
+C<do $file>, which returns the C<$app> closure; that closure does not close over a
+file-scoped C<my $ticker>, so the only reference to the running task goes out of
+scope and the task is silently destroyed. The sole symptom is a cryptic
 
     ... lost its returning future ...
 
-warning, and your timer simply never fires again.
+warning (emitted by L<Future::AsyncAwait>), and your timer simply never fires.
 
-Keep any long-lived background Future in B<package scope> so it outlives the
-load. That is the entire reason the example uses C<package PeriodicEvents; our
-$TICKER = ...> instead of a lexical. State this rule to anyone building event
-sources on PAGI before they spend an afternoon on it.
+The B<wrong> fix is to pin the orphan in a package variable:
+
+    # ANTI-PATTERN: a side-pointer that compensates for a missing parent
+    package PeriodicEvents;
+    our $TICKER = (async sub { ... })->();
+
+That stops the garbage collection, but it is a side-pointer outside the tree: the
+source's failures go nowhere (you must bolt on your own C<< ->on_fail >>), and
+nothing coordinates its shutdown. The B<right> fix is to give the future a parent
+-- root it in the lifespan scope as above, where the selector retains it,
+propagates its errors, and cancels it cleanly on shutdown.
 
 See also L<PAGI::Building> for using this pattern to build event-driven layers
 on PAGI.

--- a/lib/PAGI/EventLoops.pod
+++ b/lib/PAGI/EventLoops.pod
@@ -121,10 +121,10 @@ Prefer this tier for code you intend to be portable across servers.
 =head2 Tier 2: IO::Async-native, once you accept an IO::Async loop is running
 
 If you are content to require that an L<IO::Async> loop is the running loop, you
-can use IO::Async facilities directly -- C<IO::Async::Loop-E<gt>new>,
-C<watch_time>, the C<Net::Async::*> client modules, and so on. Under
-L<PAGI::Server> this requirement is free: the reference server I<is> IO::Async,
-so an IO::Async loop is always running and IO::Async-native code just works.
+can use IO::Async facilities directly -- timers (C<watch_time>), the
+C<Net::Async::*> client modules, and so on. Under L<PAGI::Server> this
+requirement is free: the reference server I<is> IO::Async, so an IO::Async loop
+is always running and IO::Async-native code just works.
 
 This is convenient and idiomatic on PAGI::Server. The trade-off is that you have
 named a loop, so the portability of Tier 1 is gone.
@@ -229,6 +229,9 @@ request -- nothing is blocked:
                 { count => $count, hint => 'GET /next to wait for the next tick' });
         }
     };
+
+(C<reply> is a small JSON-response helper; the full runnable version is in
+F<examples/14-periodic-events>.)
 
 This is the whole pattern: a source that resolves Futures, and a handler that
 awaits them. It composes with C<$receive> through ordinary Future combinators --
@@ -345,6 +348,17 @@ loop. If the server and the Future::IO implementation ended up on different
 loops, the handler's Futures would be scheduled on a loop that nobody is turning,
 and requests would hang. With the env var set up front they share a single EV
 loop, and everything ticks.
+
+Note: the C<BEGIN>/env-var approach is what you use when B<you> own the loop
+(embedding). When you let L<PAGI::Server> own the loop via C<run()> instead,
+there is a native shortcut -- the C<loop_type> constructor option:
+
+    PAGI::Server->new(app => $app, port => 5016, loop_type => 'EV')->run;
+
+This tells the server to create an EV-backed loop directly (it loads
+C<IO::Async::Loop::EV> internally) without requiring a C<BEGIN> block in your
+code. C<Future::IO> wiring is still handled automatically, as with any
+C<pagi-server>-owned loop.
 
 The runnable, verified version is F<examples/16-foreign-loop>.
 

--- a/lib/PAGI/EventLoops.pod
+++ b/lib/PAGI/EventLoops.pod
@@ -1,0 +1,380 @@
+=encoding UTF-8
+
+=head1 NAME
+
+PAGI::EventLoops - how PAGI stays loop-agnostic, how not to block, and how a server binds to an event loop
+
+=head1 DESCRIPTION
+
+The protocol names no event loop. A PAGI application is C<async sub ($scope,
+$receive, $send)> -- Futures and async/await, nothing more. C<await> is
+loop-neutral: it suspends on a Future, and I<which loop resumes it> depends only
+on what created the leaf Future you awaited. So the loop never enters through
+your control flow -- only through the I/O primitives you call.
+
+A PAGI app B<must not assume IO::Async, or any loop, is already set up.>
+L<PAGI::Server> is the I<reference> implementation, not I<the> implementation;
+other servers are expected, and your app should run unchanged on any of them.
+
+This document has four parts. First, why PAGI is loop-agnostic at all. Second,
+how to do real work in a handler without blocking the loop. Third, how to write
+your own event sources (timers, background jobs, external triggers) as Futures.
+Fourth -- as reference-server specifics -- how L<PAGI::Server> binds to a loop,
+including embedding it in an application that owns the loop itself.
+
+=head1 PAGI IS LOOP-AGNOSTIC
+
+Look at the application contract and notice what is I<not> there:
+
+    async sub {
+        my ($scope, $receive, $send) = @_;
+        ...
+    }
+
+There is no loop object, no reactor, no C<run> to call. The signature names
+C<$scope>, C<$receive>, and C<$send>, and that is all. Everything else is
+expressed with Futures and C<await>.
+
+C<await> is the key. When you write C<await $some_future>, your handler suspends
+until that Future is resolved. It does not say I<how> the Future gets resolved,
+or which loop is turning while it waits. That is decided entirely by whatever
+created the leaf Future at the bottom of the chain -- the socket read inside
+C<$receive>, the timer inside a C<Future::IO-E<gt>sleep>, the database driver's
+query Future. The loop enters your program only at those leaves. Your control
+flow never refers to it.
+
+This is why the same handler runs unchanged under different servers. One server
+might drive everything with L<IO::Async>; another might use a different reactor
+entirely. Your code does not change, because it never named the reactor in the
+first place. It only ever said "wait for this Future."
+
+L<PAGI::Server> happens to be built on L<IO::Async>. That is an implementation
+choice of one reference server, not a requirement of the protocol. Write to the
+contract -- Futures and C<await> -- and you are portable by construction.
+
+=head1 NOT BLOCKING INSIDE YOUR APP
+
+Loop-agnostic does not mean loop-immune. There is exactly one rule that matters
+for performance: B<a handler must never block the loop>. A single-threaded event
+loop runs your handler on the same thread that services every other connection.
+If your handler stops to wait synchronously, every other client stops with it.
+
+What counts as blocking:
+
+=over 4
+
+=item *
+
+C<sleep> (the builtin) -- stops the whole process, not just your handler.
+
+=item *
+
+Synchronous network clients -- C<LWP::UserAgent>, a blocking C<DBI> query, a
+plain socket C<read>. They return only when the I/O completes, and nothing else
+runs in the meantime.
+
+=item *
+
+Synchronous file I/O on slow or remote filesystems, and large reads done in one
+gulp.
+
+=item *
+
+CPU-bound loops -- a tight computation that runs for hundreds of milliseconds
+holds the loop just as surely as a blocking read. Yield, offload, or chunk it.
+
+=back
+
+The cure is to use an asynchronous equivalent that returns a Future and to
+C<await> it. There are three tiers of how to get one, in order of portability.
+
+=head2 Tier 1: default to Future::IO
+
+L<Future::IO> is the portable choice. It provides loop-neutral primitives --
+C<sleep>, socket reads and writes, and so on -- that return Futures without your
+code naming any loop. A handler written against Future::IO runs under any server
+whose deployment has wired a Future::IO backend (see L</Who wires the
+Future::IO backend> below).
+
+    use Future::IO;
+
+    my $app = async sub {
+        my ($scope, $receive, $send) = @_;
+        return unless ($scope->{type} // '') eq 'http';
+
+        # Non-blocking pause: the loop keeps serving other clients meanwhile.
+        await Future::IO->sleep(1);
+
+        await $send->({
+            type    => 'http.response.start',
+            status  => 200,
+            headers => [ ['content-type', 'text/plain'] ],
+        });
+        await $send->({
+            type => 'http.response.body',
+            body => "waited one second without blocking the loop\n",
+        });
+    };
+
+Prefer this tier for code you intend to be portable across servers.
+
+=head2 Tier 2: IO::Async-native, once you accept an IO::Async loop is running
+
+If you are content to require that an L<IO::Async> loop is the running loop, you
+can use IO::Async facilities directly -- C<IO::Async::Loop-E<gt>new>,
+C<watch_time>, the C<Net::Async::*> client modules, and so on. Under
+L<PAGI::Server> this requirement is free: the reference server I<is> IO::Async,
+so an IO::Async loop is always running and IO::Async-native code just works.
+
+This is convenient and idiomatic on PAGI::Server. The trade-off is that you have
+named a loop, so the portability of Tier 1 is gone.
+
+=head2 Tier 3: the honest caveat
+
+IO::Async-native code is not strictly tied to PAGI::Server, but it is tied to
+I<an IO::Async loop being the running loop>. IO::Async ships adapter loops
+(C<IO::Async::Loop::EV>, C<IO::Async::Loop::Glib>, and others) that let an
+IO::Async loop drive a foreign reactor. So Tier-2 code can run on a non-IO::Async
+host B<only> when an IO::Async loop -- possibly an adapter -- is the loop that is
+actually turning. If a host runs a different reactor with no IO::Async loop in
+play, Tier-2 code has nothing to schedule it. Tier-1 (Future::IO) code does not
+have this problem, which is exactly why it is the default recommendation.
+
+=head2 Who wires the Future::IO backend
+
+L<Future::IO> is loop-neutral until something tells it which backend to use, and
+choosing that backend is the job of the B<server or the deployer>, not the
+application. Two cases:
+
+=over 4
+
+=item *
+
+B<Running under C<bin/pagi-server>:> the Future::IO-to-IO::Async backend is
+configured B<automatically> (when Future::IO is installed). You write
+Future::IO-based handlers and they tick; you do nothing.
+
+=item *
+
+B<Embedding L<PAGI::Server> yourself:> B<you> must wire it. Add
+
+    use Future::IO::Impl::IOAsync;
+
+before loading any Future::IO-based libraries, so that Future::IO resolves its
+primitives on the IO::Async loop your embedded server is running.
+
+=back
+
+This is documented in full on the server side; rather than repeat it here, see
+L<PAGI::Server/LOOP INTEROPERABILITY>.
+
+=head1 WRITING YOUR OWN EVENT SOURCE
+
+The protocol gives you C<$receive> for client-driven events. But a handler often
+needs to wait on something the client did not send: a timer firing, a background
+job finishing, a message arriving on an external queue. The loop-agnostic way to
+do this is to B<model the event as a Future> and let the handler C<await> it,
+exactly as it awaits C<$receive>. You introduce no new scope types and need no
+server cooperation -- the source is just ordinary Future plumbing inside your
+program. (See L<PAGI::Spec::Extensions/"Defining your own events"> for where
+this sits in the extension model.)
+
+A worked example: a background ticker that fires every couple of seconds, plus a
+long-poll endpoint that lets a client wait for the next tick. The runnable
+version is F<examples/14-periodic-events>; the teaching essentials follow.
+
+First, keep the source out of C<main::> and give it its own package. The reason
+is not cosmetic -- see the lifetime note below.
+
+    package PeriodicEvents;
+
+    use Future::AsyncAwait;
+    use Future::IO;
+
+    my $INTERVAL = 2;
+    my $count    = 0;
+    my @waiters;   # Futures awaiting the next tick
+
+The source itself is an async loop whose only timer is a C<Future::IO-E<gt>sleep>,
+so it names no event loop -- it runs on whatever loop the server is using. Each
+tick resolves every Future currently waiting:
+
+    our $TICKER = (async sub {
+        while (1) {
+            await Future::IO->sleep($INTERVAL);
+            $count++;
+            my $result = { tick => $count, at => time };
+            my @pending = @waiters;
+            @waiters = ();
+            $_->done($result) for @pending;
+        }
+    })->();
+    $TICKER->on_fail(sub { warn "periodic source failed: $_[0]\n" });
+
+The handler "listens" for the next event by creating a Future, pushing it onto
+the waiter list, and awaiting it. While it waits, the loop serves every other
+request -- nothing is blocked:
+
+    my $app = async sub {
+        my ($scope, $receive, $send) = @_;
+        return unless ($scope->{type} // '') eq 'http';
+
+        if ($scope->{path} eq '/next') {
+            my $f = Future->new;
+            push @waiters, $f;
+            await reply($send, 200, await $f);
+        }
+        else {
+            await reply($send, 200,
+                { count => $count, hint => 'GET /next to wait for the next tick' });
+        }
+    };
+
+This is the whole pattern: a source that resolves Futures, and a handler that
+awaits them. It composes with C<$receive> through ordinary Future combinators --
+C<Future-E<gt>wait_any($receive-E<gt>(), $my_event)> waits on a client message
+or your own event, whichever arrives first.
+
+=head2 A lifetime footgun
+
+The C<our $TICKER> above is not a style choice -- it is load-bearing. A
+background task whose Future is held only in a file-scoped C<my> is garbage
+collected once the app finishes loading. Under C<pagi-server> the app is loaded
+with C<do $file>, which returns the C<$app> closure; that closure does not close
+over a file-scoped C<my $ticker>, so the only reference to the running task goes
+out of scope and the task is silently destroyed. The sole symptom is a cryptic
+
+    ... lost its returning future ...
+
+warning, and your timer simply never fires again.
+
+Keep any long-lived background Future in B<package scope> so it outlives the
+load. That is the entire reason the example uses C<package PeriodicEvents; our
+$TICKER = ...> instead of a lexical. State this rule to anyone building event
+sources on PAGI before they spend an afternoon on it.
+
+See also L<PAGI::Building> for using this pattern to build event-driven layers
+on PAGI.
+
+=head1 BINDING A SERVER TO AN EVENT LOOP
+
+Everything above is protocol-level and server-neutral. This section is different:
+it is about L<PAGI::Server> specifically -- the reference server -- and how it
+attaches to an L<IO::Async> loop. Other servers will bind differently.
+
+=head2 Owning the loop versus embedding
+
+The simple case is to let the server own the loop:
+
+    PAGI::Server->new(app => $app, port => 5000)->run;
+
+C<run> creates the loop, listens, and runs until stopped. This is what
+C<bin/pagi-server> does, and it is all most deployments need.
+
+The other case is B<embedding>: you already have an IO::Async application with
+its own loop, and you want a PAGI::Server to share it. PAGI::Server is an
+C<IO::Async::Notifier>, so you add it to your loop, start listening, and run your
+own loop:
+
+    use IO::Async::Loop;
+    use Future::IO::Impl::IOAsync;   # we embed, so WE wire the Future::IO backend
+    use PAGI::Server;
+
+    my $loop = IO::Async::Loop->new;
+
+    my $server = PAGI::Server->new(app => $app, port => 5015);
+    $loop->add($server);
+    $server->listen->get;     # listen without running the loop
+    $loop->run;               # the host app owns the loop
+
+Three points about this pattern:
+
+=over 4
+
+=item *
+
+You call C<$loop-E<gt>add($server)> to attach the server to your loop, then
+C<$server-E<gt>listen-E<gt>get> to bind the socket I<without> running the loop,
+then C<$loop-E<gt>run> when your host application is ready to turn it.
+
+=item *
+
+There is no C<start> method and no C<< loop => >> constructor argument. You
+attach with C<add> and listen with C<listen>; that is the whole API.
+
+=item *
+
+Because you are embedding rather than going through C<bin/pagi-server>, B<you>
+wire the Future::IO backend with C<use Future::IO::Impl::IOAsync> -- see
+L</Who wires the Future::IO backend> above. Without it, Future::IO-based handlers
+will not tick.
+
+=back
+
+The runnable version, including a host-app timer that proves the server and the
+host share one loop, is F<examples/15-embedded-ioasync>.
+
+=head2 Running under a foreign (EV-backed) loop
+
+You can run PAGI::Server under a non-default reactor by giving IO::Async an
+adapter loop. The verified case is L<EV>: PAGI::Server runs under an EV-backed
+IO::Async loop, and Future::IO ticks correctly there -- a
+C<Future::IO-E<gt>sleep(1)> inside a handler resolves and the request returns in
+about a second.
+
+The wiring has three parts:
+
+    BEGIN { $ENV{IO_ASYNC_LOOP} = 'EV' }   # before any IO::Async load
+    use IO::Async::Loop;
+    use Future::IO;
+    use Future::IO::Impl::IOAsync;          # embedder wires the Future::IO backend
+    use PAGI::Server;
+
+    my $loop = IO::Async::Loop->new;        # EV-backed, per IO_ASYNC_LOOP above
+
+    my $server = PAGI::Server->new(app => $app, port => 5016);
+    $loop->add($server);
+    $server->listen->get;
+    $loop->run;
+
+The C<IO_ASYNC_LOOP> environment variable is the load-bearing part. It must be
+set in a C<BEGIN> block, before any IO::Async module is loaded, so that I<every>
+C<IO::Async::Loop-E<gt>new> in the process -- both the one you create and the one
+Future::IO's IO::Async backend uses internally -- resolves to the same EV-backed
+loop. If the server and the Future::IO implementation ended up on different
+loops, the handler's Futures would be scheduled on a loop that nobody is turning,
+and requests would hang. With the env var set up front they share a single EV
+loop, and everything ticks.
+
+The runnable, verified version is F<examples/16-foreign-loop>.
+
+=head1 SEE ALSO
+
+=over 4
+
+=item L<PAGI::Spec> - the specification
+
+=item L<PAGI::Spec::Extensions> - the extension mechanism and custom events
+
+=item L<PAGI::Building> - building a framework or toolkit on PAGI
+
+=item L<PAGI::Server/LOOP INTEROPERABILITY> - who wires the Future::IO backend, in full
+
+=item L<Future::IO> - loop-neutral, portable async I/O primitives
+
+=item L<IO::Async> - the reactor the reference server is built on
+
+=back
+
+And the runnable examples: F<examples/14-periodic-events>,
+F<examples/15-embedded-ioasync>, and F<examples/16-foreign-loop>.
+
+=head1 AUTHOR
+
+John Napiorkowski E<lt>jjnapiork@cpan.orgE<gt>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is licensed under the same terms as Perl itself.
+
+=cut

--- a/lib/PAGI/PSGI.pod
+++ b/lib/PAGI/PSGI.pod
@@ -287,6 +287,8 @@ about fifty lines of plain Perl.
 
 =item L<PSGI> - the synchronous predecessor
 
+=item L<PAGI::EventLoops> - event loops, non-blocking I/O, and binding a server to a loop
+
 =back
 
 =head1 AUTHOR

--- a/lib/PAGI/Tutorial.pod
+++ b/lib/PAGI/Tutorial.pod
@@ -1765,6 +1765,8 @@ You've covered the PAGI protocol! For more information:
 
 =item * L<Future::IO> - Loop-agnostic async primitives (sleep, I/O)
 
+=item * L<PAGI::EventLoops> - event loops, non-blocking I/O, and binding a server to a loop
+
 =back
 
 =head1 AUTHOR


### PR DESCRIPTION
## Summary

Adds **`PAGI::EventLoops`**, a new top-level doc in the spec distribution that addresses a recurring confusion: that PAGI is tied to IO::Async. It establishes the governing principle — *the protocol names no loop; loop-dependence enters only at the I/O leaves; an app must not assume IO::Async; `PAGI::Server` is the **reference** server, not the only one* — and then covers four areas, with code drawn from three **runnable, verified** examples.

### The document (`lib/PAGI/EventLoops.pod`)
- **A. Loop-agnosticism** — `async sub ($scope,$receive,$send)` names no loop; `await` is loop-neutral.
- **B. Not blocking in your app** — three-tier guidance (default to `Future::IO`; IO::Async-native once you accept an IO::Async loop is running; the honest caveat for non-IO::Async hosts), plus the Future::IO-backend-wiring crux, cross-linked to `PAGI::Server/LOOP INTEROPERABILITY` rather than duplicated.
- **C. Writing your own event source** — model timers/background work as Futures; includes the background-Future lifetime footgun and its fix.
- **D. Binding a server to a loop** — owning (`run`) vs embedding (`$loop->add`/`listen->get`/`run`); foreign-loop hosting under EV (with the `loop_type` shortcut noted).

### Examples (each with its own `cpanfile`)
- `examples/14-periodic-events` — in-app `Future::IO` periodic event source + long-poll listener.
- `examples/15-embedded-ioasync` — embed `PAGI::Server` in a larger IO::Async program.
- `examples/16-foreign-loop` — `PAGI::Server` running under an EV-backed IO::Async loop; verified that `Future::IO` ticks there.

### Discoverability
- Listed in `examples/README.md`; `PAGI::EventLoops` added to the SEE ALSO of `Building`, `Tutorial`, `Cookbook`, and `PSGI`.

## Verification
- All three examples were run and confirmed (real server + curl); D2 (EV) independently re-confirmed.
- `podchecker` clean; full suite `prove -l t/` passes (20 tests).

## Notes
- No invented API — the doc explicitly states `PAGI::Server` has no `start()` method and no `loop =>` constructor (the embedding API is `$loop->add`/`listen->get`/`run`).
- Surfaced one footgun for follow-up (tracked separately): background Futures held in a file-scoped `my` are GC'd after `pagi-server`'s `do $file`, dying silently with a cryptic "lost its returning future" warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)