### PR TITLE
spec: define server behavior for incomplete returns and lifespan decline

### DIFF
--- a/lib/PAGI/Spec.pod
+++ b/lib/PAGI/Spec.pod
@@ -331,6 +331,8 @@ Applications B<must> await all C<$send> calls before their Future completes:
 
 Work scheduled via C<<< ->retain >>> or other fire-and-forget patterns will race with connection cleanup and produce undefined behavior. The server has no visibility into retained Futures - they exist outside the application's Future tree.
 
+If the application's Future resolves B<without> the scope's protocol having been completed -- for example, an C<http> application returns having sent no C<http.response.start> -- the server B<must not> treat the connection as cleanly finished. It surfaces the incompleteness in a protocol-specific way (for HTTP, see L<PAGI::Spec::Www/Incomplete Responses>; for the lifespan scope, see L<PAGI::Spec::Lifespan>). This is distinct from declining: an application that does not handle a scope at all B<must> raise an exception (see L</Applications>), not return -- a clean return that completes nothing is a programming error a server cannot distinguish from a bug.
+
 B<Use C<PAGI::Middleware::Lint>> during development to detect incomplete responses.
 
 =head3 Legacy Applications

--- a/lib/PAGI/Spec/Lifespan.pod
+++ b/lib/PAGI/Spec/Lifespan.pod
@@ -115,8 +115,25 @@ C<state> (HashRef, optional) - A namespace where the application can persist val
 
 =back
 
-If an exception is raised when calling the application coderef with a
-C<lifespan.startup> message (or when a C<lifespan> scope is created), the server must cease sending further lifespan events for that worker. The server should log the error and may either exit or continue starting without lifespan support, depending on operator configuration. Applications that wish to prevent startup entirely should explicitly send C<lifespan.startup.failed> with a message.
+If the application B<declines> the lifespan protocol -- either by raising an
+exception when called with the C<lifespan> scope, or by returning without ever
+sending C<lifespan.startup.complete> or C<lifespan.startup.failed> -- the server
+B<must> treat lifespan as unsupported: it B<must> continue startup, B<must not>
+send further lifespan events for that worker, and B<should> log this at an
+informational level. A raised exception and a clean return are resolved
+identically, and the server B<must not> block startup indefinitely waiting for a
+lifespan signal.
+
+To prevent startup entirely, an application B<must> send
+C<lifespan.startup.failed> with a message; on receiving it the server B<must>
+abort startup (it B<must not> begin accepting connections) and B<should> log the
+message. This is the B<only> application signal that prevents the server from
+starting -- a clean return B<must not>.
+
+If the application raises an exception B<after> it has sent
+C<lifespan.startup.complete> -- for example, a long-lived background task started
+during lifespan crashes -- the server B<should> log the error at error level and
+B<may> continue running in a degraded state. It is not required to shut down.
 
 =head2 Lifespan State
 

--- a/lib/PAGI/Spec/Www.pod
+++ b/lib/PAGI/Spec/Www.pod
@@ -571,6 +571,26 @@ C<headers> (ArrayRef[ArrayRef[Bytes]], default C<[]>) -- Trailer headers encoded
 
 =back
 
+=head3 Incomplete Responses
+
+If an HTTP application's Future resolves while the response is incomplete, and the client is B<still connected>, the server MUST surface it rather than silently closing the connection as finished:
+
+=over
+
+=item -
+
+If no C<http.response.start> was sent, the server MUST send a C<500> response and log the error.
+
+=item -
+
+If C<http.response.start> was sent but the body was not completed, the server MUST close the connection and log the error. A status line has already been transmitted, so a C<500> is no longer possible.
+
+=back
+
+If the client has B<already disconnected> (see L</Disconnect - C<receive> event>), neither case is an application error: the server MUST NOT synthesize a C<500> and MUST NOT log an error.
+
+This is the same handling the server applies when an application B<declines> the C<http> scope by raising an exception (see L<PAGI::Spec/Applications>): C<500> if no response was started, otherwise close. Declining by raising is the required idiom; a bare return that starts no response is treated identically but is a programming error rather than an intentional signal.
+
 =head3 Server-Supplied Headers and Behaviors
 
 Beyond the headers an application sets on C<http.response.start>, a conforming


### PR DESCRIPTION
## Why

The spec already requires an application to **decline** an unsupported scope by **raising** (`Spec.pod`: "Applications MUST throw an exception if `scope->{type}` is not supported"). But it was **silent** on what a server does when an application's Future resolves *without completing* the scope's protocol — the gap that surfaced while investigating lifespan failure handling (an HTTP-only app that declined lifespan by a bare `return` instead of raising). This fills that gap.

Behavior is grounded in the ASGI ecosystem (uvicorn / hypercorn / granian, primary-source verified) and matches PAGI's reference server.

## Changes

- **`Spec.pod` — Application Completion Contract:** a Future that resolves without completing the scope's protocol is **not** a clean finish; the server surfaces it per-protocol. This is explicitly distinct from declining (which MUST be a raise, not a return).
- **`Www.pod` — new "Incomplete Responses":** for HTTP, if the app returns with no `http.response.start` → server MUST send **500** + log; if started but body incomplete → MUST **close** + log. Carve-out: if the client already disconnected, it is not an application error (no 500, no log).
- **`Lifespan.pod`:** a clean return without `startup.complete`/`startup.failed` is treated as **"lifespan unsupported, continue"** — identical to a raise; the server MUST NOT block startup indefinitely; only `lifespan.startup.failed` aborts startup; and a **post-startup** exception is logged at error and may continue degraded.

## Cross-refs
- Reference-server behavior implemented in PAGI-Server PR #1 (lifespan logging + clean-return handling).
- Example idiom (`die`, not `return`) corrected in PAGI PR #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)