### PR TITLE
spec: soften no-response handling; drop the completion judgment

### DIFF
--- a/lib/PAGI/Spec.pod
+++ b/lib/PAGI/Spec.pod
@@ -331,7 +331,18 @@ Applications B<must> await all C<$send> calls before their Future completes:
 
 Work scheduled via C<<< ->retain >>> or other fire-and-forget patterns will race with connection cleanup and produce undefined behavior. The server has no visibility into retained Futures - they exist outside the application's Future tree.
 
-If the application's Future resolves B<without> the scope's protocol having been completed -- for example, an C<http> application returns having sent no C<http.response.start> -- the server B<must not> treat the connection as cleanly finished. It surfaces the incompleteness in a protocol-specific way (for HTTP, see L<PAGI::Spec::Www/Incomplete Responses>; for the lifespan scope, see L<PAGI::Spec::Lifespan>). This is distinct from declining: an application that does not handle a scope at all B<must> raise an exception (see L</Applications>), not return -- a clean return that completes nothing is a programming error a server cannot distinguish from a bug.
+If an C<http> application's Future resolves without any C<http.response.start>
+having been sent -- and the client is still connected -- the client is left
+waiting for a response that will never arrive. As a last-resort B<backstop> the
+server produces a response (a C<500>) and logs it; see
+L<PAGI::Spec::Www/"Application Produced No Response">. This is a backstop, B<not> a
+completion policy: which terminal response to produce (a C<404>, a C<204>, an
+error page, ...) is the application's or framework's concern, and a well-behaved
+application always produces one before its Future resolves. PAGI exposes only the
+observer-independent fact that no response was started; it makes no judgment about
+whether a response is "complete". An application that does not handle a scope at
+all should decline by raising (see L</Applications>), which the server surfaces
+the same way. (For the lifespan scope, see L<PAGI::Spec::Lifespan>.)
 
 B<Use C<PAGI::Middleware::Lint>> during development to detect incomplete responses.
 

--- a/lib/PAGI/Spec/Www.pod
+++ b/lib/PAGI/Spec/Www.pod
@@ -571,25 +571,26 @@ C<headers> (ArrayRef[ArrayRef[Bytes]], default C<[]>) -- Trailer headers encoded
 
 =back
 
-=head3 Incomplete Responses
+=head3 Application Produced No Response
 
-If an HTTP application's Future resolves while the response is incomplete, and the client is B<still connected>, the server MUST surface it rather than silently closing the connection as finished:
+If an HTTP application's Future resolves without any C<http.response.start> having
+been sent, and the client is B<still connected>, the client is left waiting for a
+response that will never come. As a last-resort B<backstop> the server produces a
+C<500> response, logs it, and closes the connection so the client is not left
+hanging.
 
-=over
+This is a backstop, B<not> a completion policy. Which terminal response to produce
+-- a C<404>, a C<204>, an error page, or anything else -- is the application's or
+framework's responsibility, and a well-behaved application always produces one
+before its Future resolves. PAGI exposes only the observer-independent fact that
+no response was started (see the C<pagi.connection> object and the application's
+own bookkeeping); it makes B<no> judgment about whether a response is "complete".
+An application that does not handle the C<http> scope may decline by raising an
+exception, which the server treats identically -- the same C<500> backstop.
 
-=item -
-
-If no C<http.response.start> was sent, the server MUST send a C<500> response and log the error.
-
-=item -
-
-If C<http.response.start> was sent but the body was not completed, the server MUST close the connection and log the error. A status line has already been transmitted, so a C<500> is no longer possible.
-
-=back
-
-If the client has B<already disconnected> (see L</Disconnect - C<receive> event>), neither case is an application error: the server MUST NOT synthesize a C<500> and MUST NOT log an error.
-
-This is the same handling the server applies when an application B<declines> the C<http> scope by raising an exception (see L<PAGI::Spec/Applications>): C<500> if no response was started, otherwise close. Declining by raising is the required idiom; a bare return that starts no response is treated identically but is a programming error rather than an intentional signal.
+If the client has B<already disconnected> (see L</Disconnect - C<receive> event>),
+this is not an application error: the server MUST NOT synthesize a C<500> and MUST
+NOT log an error.
 
 =head3 Server-Supplied Headers and Behaviors
 


### PR DESCRIPTION
Follow-up to #53. While implementing the started-but-incomplete case, we hit a contradiction with guidance given to the Thunderhorse framework author: PAGI deliberately exposes **observer-independent facts** (`is_sent`, `has_status`, `has_body_source`), **not** a `ready`/`complete` predicate, because completion semantics belong to the framework. And in an async model the server has **no easy, reliable way** to judge body completion (a response can be produced right up to the moment the app's Future resolves).

The #53 "Incomplete Responses" section over-reached: it had the server judge body completion (close+log on a started-but-incomplete body) and called a bare return a "programming error".

This PR reframes it as **"Application Produced No Response"**:
- The server's **500 is a last-resort backstop** for when **no** `http.response.start` was sent (otherwise the client hangs). It is explicitly **not** a completion policy.
- The terminal response (`404`/`204`/error page/...) is the **application's or framework's** responsibility; a well-behaved app always produces one.
- **Dropped** the started-but-incomplete "completion" clause entirely.
- Kept the disconnect carve-out.
- Synced the matching paragraph in `Spec.pod`'s Application Completion Contract.

The reference-server behavior (PAGI-Server #3: no response → 500) already matches this softened wording; no completion-tracking flag was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)