### PR TITLE
Docs: scope clone/share model — terse in the spec, full in the guides

### DIFF
--- a/lib/PAGI/Building.pod
+++ b/lib/PAGI/Building.pod
@@ -80,7 +80,8 @@ inner handlers via the scope, and to the client via a response header:
             my ($scope, $receive, $send) = @_;
 
             my $id = ++$counter;
-            $scope->{'myapp.request_id'} = $id;   # inner handlers can read this
+            my $inner = { %$scope };               # clone before modifying
+            $inner->{'myapp.request_id'} = $id;    # inner handlers can read this
 
             my $wrapped_send = async sub {
                 my ($event) = @_;
@@ -90,7 +91,7 @@ inner handlers via the scope, and to the client via a response header:
                 return await $send->($event);
             };
 
-            return await $app->($scope, $receive, $wrapped_send);
+            return await $app->($inner, $receive, $wrapped_send);
         };
     }
 
@@ -98,6 +99,95 @@ To short-circuit -- an authentication gate, say -- a middleware simply sends its
 own response and returns without ever calling C<$app>. This is the same shape as
 PSGI middleware, one level asynchronous; if you have written PSGI middleware,
 you already know how to write this.
+
+=head2 Scope is cloned per layer, not shared
+
+Notice the example clones the scope (C<< my $inner = { %$scope } >>) before
+stamping its key, rather than writing to C<$scope> directly. The specification
+requires this: middleware must not mutate the scope they were handed.
+
+The reason is isolation. Middleware form an onion -- each layer wraps the next, a
+request descends through them to the application, and control rises back out.
+Cloning on the way down keeps each layer's scope edits B<local to itself and the
+layers below it>. A middleware that rewrites C<path>, negotiates a content type,
+or stamps a request id changes the scope only for the inner application; its
+sibling and parent layers, and the server's own view of the scope, are untouched.
+Mutating in place would let those edits B<leak upward> and bleed between unrelated
+layers. Scope edits flow B<downward only>.
+
+(This is the one place PAGI departs from PSGI's single C<$env> mutated in place.
+If you are coming from PSGI, see L<PAGI::PSGI> for the migration note.)
+
+=head2 Shallow, not deep
+
+The clone is B<shallow> -- C<{ %$scope }> copies the top-level key/value pairs
+into a new hashref and nothing more -- and that is deliberate. It produces a
+precise asymmetry:
+
+=over
+
+=item *
+
+B<Top-level keys are private.> Adding, removing, or replacing a key on the clone
+(C<< $inner->{x} = ... >>) affects only that clone and the layers below it. This
+is the isolation above.
+
+=item *
+
+B<Referenced values are shared.> When a key's value is a reference -- a hashref,
+arrayref, or object -- the clone copies the B<reference>, not what it points at.
+Every layer holds the same underlying thing, so mutating I<through> the reference
+(C<< $inner->{conn}->mark(...) >>, C<< $inner->{state}{count}++ >>) is visible to
+B<all> layers, above and below.
+
+=back
+
+PAGI depends on this asymmetry. The server seeds shared objects into the scope
+B<before> any middleware runs -- the C<pagi.connection> connection-state object,
+the lifespan C<state> namespace (L<PAGI::Spec::Lifespan/Lifespan State>) -- so
+every layer shares the one instance. A B<deep> clone would copy those per layer,
+giving each middleware its own disconnected C<pagi.connection> and its own copy of
+the database pool, breaking disconnect propagation, lifespan sharing, and the
+escape hatch below. Shallow cloning is not an optimization; the shared references
+are the point.
+
+=head2 The footgun: scalars do not propagate
+
+The trap follows directly: B<a plain scalar set as a top-level scope key does not
+propagate across layers>. Set C<< $inner->{'myapp.sent'} = 1 >> in an inner layer
+and an outer layer will never see it -- the shallow clone snapshotted the scalar
+by value. This is true in any language with shallow copy (Python's C<dict(scope)>
+behaves identically); it is not a Perl quirk. If you find yourself setting a
+scope flag in one layer and reading it in another, this is why it "vanishes."
+
+=head2 Sharing state across layers
+
+To deliberately share mutable per-request state, use a B<reference>, and make sure
+it exists B<before> the layers that need to share it:
+
+=over
+
+=item *
+
+To share B<downward> (an outer middleware hands state to inner layers), seed a
+reference on the scope before descending -- C<< $inner->{'myapp.ctx'} = {} >> --
+then inner layers mutate through it.
+
+=item *
+
+To share B<upward> (an inner layer reports back to an outer one), the shared
+reference must already exist at or above the outer layer before the clone. A
+B<new> top-level key created deep in the stack cannot bubble up, by design.
+
+=back
+
+L<PAGI::Stash> packages this pattern: it wraps a single C<pagi.stash> hashref, so
+any layer holding the scope reads and writes shared per-request state through the
+one reference. Seed it high -- in the server or an outer middleware -- and it
+propagates in both directions.
+
+Rule of thumb: B<top-level scope keys describe your layer's view of the request;
+shared mutable state lives behind a reference.>
 
 =head1 EXTENDING THE PROTOCOL
 

--- a/lib/PAGI/PSGI.pod
+++ b/lib/PAGI/PSGI.pod
@@ -163,6 +163,16 @@ events, or short-circuit entirely. Adding a response header:
         };
     }
 
+One difference will bite you if you do not know it. In PSGI, C<$env> is a single
+hashref shared down the whole stack and mutated in place, so a key one layer sets
+is visible everywhere. In PAGI, middleware B<clone> the scope before modifying it,
+and the clone is shallow -- so a plain scalar you set in one layer does B<not>
+propagate to another the way a C<$env> key would. This is deliberate (it isolates
+each layer's scope edits), and the way to share state on purpose is to mutate
+B<through a reference> rather than set a top-level scalar -- L<PAGI::Stash> wraps
+exactly that. See L<PAGI::Building/"Scope is cloned per layer, not shared"> for
+the full model.
+
 The middleware model for framework authors is covered in depth in
 L<PAGI::Building>. Server-advertised C<psgix.*> extensions become
 C<< $scope->{extensions} >> (see L<PAGI::Spec::Extensions>).

--- a/lib/PAGI/Spec.pod
+++ b/lib/PAGI/Spec.pod
@@ -425,11 +425,99 @@ PAGI middleware wraps an application:
             }
             return $result;
 
-            # Middleware should default to shallow cloning and explicitly deep clone if required.
+            # Shallow clone (see below): top-level edits stay local to inner
+            # layers; values reached through a shared reference propagate.
         };
     }
 
-Middleware B<must not> mutate the original C<$scope> in-place; always clone before modification.
+Middleware B<must not> mutate the original C<$scope> in-place; always clone
+before modification:
+
+    my $inner_scope = { %$scope };          # shallow clone
+    $inner_scope->{'myapp.flag'} = 1;       # visible to inner layers only
+    await $app->($inner_scope, $receive, $send);
+
+=head4 Why scope is cloned: onion isolation
+
+Middleware form an onion: each layer wraps the next, a request descends through
+them to the application, and control rises back out. Cloning the scope on the way
+down keeps each layer's scope edits B<local to itself and the layers below it>. A
+middleware that rewrites C<path>, negotiates a content type, or stashes a decoded
+identity changes the scope only for the inner application -- its sibling and
+parent layers, and the server's own view of the scope, are untouched. Without the
+clone those edits would B<leak upward> and bleed between unrelated layers.
+
+This is a deliberate departure from PSGI, where the C<$env> hashref is a single
+shared structure mutated in place and every change is visible everywhere. PAGI
+chooses isolation: scope edits flow B<downward only>.
+
+=head4 Shallow, not deep -- and why it matters
+
+The clone is B<shallow>: C<{ %$scope }> copies the top-level key/value pairs into
+a new hashref and nothing more. This produces a precise, intentional asymmetry:
+
+=over
+
+=item -
+
+B<Top-level keys are private.> Adding, removing, or replacing a key on the clone
+(C<< $inner->{x} = ... >>) affects only that clone and the layers below it. This
+is the isolation described above.
+
+=item -
+
+B<Referenced values are shared.> When a key's value is a reference -- a hashref,
+arrayref, or object -- the clone copies the B<reference>, not what it points at.
+Every layer holds the same underlying thing, so mutating I<through> the reference
+(C<< $inner->{conn}->mark(...) >>, C<< $inner->{state}{count}++ >>) is visible to
+B<all> layers, above and below.
+
+=back
+
+PAGI depends on this asymmetry. Server-supplied shared objects -- the
+C<pagi.connection> connection-state object, the lifespan C<state> namespace (see
+L<PAGI::Spec::Lifespan/Lifespan State>) -- are references seeded into the scope
+B<before> any middleware runs, so every layer shares the one instance. A B<deep>
+clone would copy those objects per layer, giving each middleware its own
+disconnected C<pagi.connection> and its own copy of the database pool -- breaking
+disconnect propagation, lifespan sharing, and the escape hatch below. Shallow
+cloning is therefore not an optimization; the shared references are the point.
+
+=head4 The footgun, and the jailbreak
+
+The trap, especially coming from PSGI/Plack: B<a plain scalar set as a top-level
+scope key does not propagate across layers>. Set C<< $inner->{'myapp.sent'} = 1 >>
+in an inner layer and an outer layer will never see it -- the shallow clone
+snapshotted the scalar by value. This is true in every language with shallow copy
+(Python's C<dict(scope)> behaves identically); it is not a Perl quirk.
+
+To deliberately share mutable per-request state across layers -- the B<jailbreak>
+-- use a B<reference>, and make sure it exists B<before> the layers that need to
+share it:
+
+=over
+
+=item -
+
+To share B<downward> (an outer middleware hands state to inner layers), seed a
+reference on the scope before descending -- C<< $inner->{'myapp.ctx'} = {} >> --
+then inner layers mutate through it.
+
+=item -
+
+To share B<upward> (an inner layer reports back to an outer one), the shared
+reference must already exist at or above the outer layer before the clone. A
+B<new> top-level key created deep in the stack cannot bubble up, by design.
+
+=back
+
+Helpers such as L<PAGI::Stash> package this pattern: the stash wraps a single
+C<pagi.stash> hashref, so any layer holding the scope reads and writes shared
+per-request state through the one reference. Seed it high -- in the server or an
+outer middleware -- and it propagates in both directions.
+
+Rule of thumb: B<top-level scope keys describe your layer's view of the request;
+shared mutable state lives behind a reference.>
 
 =head3 Cancellation and Disconnects
 

--- a/lib/PAGI/Spec.pod
+++ b/lib/PAGI/Spec.pod
@@ -425,99 +425,23 @@ PAGI middleware wraps an application:
             }
             return $result;
 
-            # Shallow clone (see below): top-level edits stay local to inner
-            # layers; values reached through a shared reference propagate.
+            # Shallow-clone the scope before modifying it (see below).
         };
     }
 
-Middleware B<must not> mutate the original C<$scope> in-place; always clone
-before modification:
+Middleware B<must not> mutate the original C<$scope> in place; clone before
+modifying:
 
-    my $inner_scope = { %$scope };          # shallow clone
-    $inner_scope->{'myapp.flag'} = 1;       # visible to inner layers only
-    await $app->($inner_scope, $receive, $send);
+    my $inner = { %$scope };
+    $inner->{'myapp.x'} = 1;
+    await $app->($inner, $receive, $send);
 
-=head4 Why scope is cloned: onion isolation
-
-Middleware form an onion: each layer wraps the next, a request descends through
-them to the application, and control rises back out. Cloning the scope on the way
-down keeps each layer's scope edits B<local to itself and the layers below it>. A
-middleware that rewrites C<path>, negotiates a content type, or stashes a decoded
-identity changes the scope only for the inner application -- its sibling and
-parent layers, and the server's own view of the scope, are untouched. Without the
-clone those edits would B<leak upward> and bleed between unrelated layers.
-
-This is a deliberate departure from PSGI, where the C<$env> hashref is a single
-shared structure mutated in place and every change is visible everywhere. PAGI
-chooses isolation: scope edits flow B<downward only>.
-
-=head4 Shallow, not deep -- and why it matters
-
-The clone is B<shallow>: C<{ %$scope }> copies the top-level key/value pairs into
-a new hashref and nothing more. This produces a precise, intentional asymmetry:
-
-=over
-
-=item -
-
-B<Top-level keys are private.> Adding, removing, or replacing a key on the clone
-(C<< $inner->{x} = ... >>) affects only that clone and the layers below it. This
-is the isolation described above.
-
-=item -
-
-B<Referenced values are shared.> When a key's value is a reference -- a hashref,
-arrayref, or object -- the clone copies the B<reference>, not what it points at.
-Every layer holds the same underlying thing, so mutating I<through> the reference
-(C<< $inner->{conn}->mark(...) >>, C<< $inner->{state}{count}++ >>) is visible to
-B<all> layers, above and below.
-
-=back
-
-PAGI depends on this asymmetry. Server-supplied shared objects -- the
-C<pagi.connection> connection-state object, the lifespan C<state> namespace (see
-L<PAGI::Spec::Lifespan/Lifespan State>) -- are references seeded into the scope
-B<before> any middleware runs, so every layer shares the one instance. A B<deep>
-clone would copy those objects per layer, giving each middleware its own
-disconnected C<pagi.connection> and its own copy of the database pool -- breaking
-disconnect propagation, lifespan sharing, and the escape hatch below. Shallow
-cloning is therefore not an optimization; the shared references are the point.
-
-=head4 The footgun, and the jailbreak
-
-The trap, especially coming from PSGI/Plack: B<a plain scalar set as a top-level
-scope key does not propagate across layers>. Set C<< $inner->{'myapp.sent'} = 1 >>
-in an inner layer and an outer layer will never see it -- the shallow clone
-snapshotted the scalar by value. This is true in every language with shallow copy
-(Python's C<dict(scope)> behaves identically); it is not a Perl quirk.
-
-To deliberately share mutable per-request state across layers -- the B<jailbreak>
--- use a B<reference>, and make sure it exists B<before> the layers that need to
-share it:
-
-=over
-
-=item -
-
-To share B<downward> (an outer middleware hands state to inner layers), seed a
-reference on the scope before descending -- C<< $inner->{'myapp.ctx'} = {} >> --
-then inner layers mutate through it.
-
-=item -
-
-To share B<upward> (an inner layer reports back to an outer one), the shared
-reference must already exist at or above the outer layer before the clone. A
-B<new> top-level key created deep in the stack cannot bubble up, by design.
-
-=back
-
-Helpers such as L<PAGI::Stash> package this pattern: the stash wraps a single
-C<pagi.stash> hashref, so any layer holding the scope reads and writes shared
-per-request state through the one reference. Seed it high -- in the server or an
-outer middleware -- and it propagates in both directions.
-
-Rule of thumb: B<top-level scope keys describe your layer's view of the request;
-shared mutable state lives behind a reference.>
+The clone is shallow, and intentionally so: top-level keys set on the clone are
+private to this layer and the layers below it, while values reached I<through> a
+reference -- the C<pagi.connection> object, the lifespan C<state> namespace --
+are shared across all layers. This keeps each middleware's scope edits
+B<downward only>. See L<PAGI::Building/MIDDLEWARE> for the sharing model, why the
+clone is shallow rather than deep, and patterns for sharing state across layers.
 
 =head3 Cancellation and Disconnects
 

--- a/lib/PAGI/Tutorial.pod
+++ b/lib/PAGI/Tutorial.pod
@@ -1584,6 +1584,16 @@ When you use C<-E<gt>retain>, you're creating a detached Future outside the tree
 
 The server only sees the tree. Detached futures are orphaned.
 
+=head3 A Scope Key Set in Middleware "Vanishes"
+
+If you set a plain value on C<$scope> in one middleware and try to read it in
+another, you may find it missing. Middleware clone the scope before modifying it,
+and the clone is shallow: a top-level scalar set in one layer does not propagate
+to the others. To share per-request state across layers on purpose, mutate
+B<through a reference> (or use the C<stash>) rather than setting a top-level
+scalar. The full model -- and why it works this way -- is in
+L<PAGI::Building/"Scope is cloned per layer, not shared">.
+
 =head3 Summary
 
 =over 4


### PR DESCRIPTION
## Why

PAGI scope is shallow-cloned per middleware layer: top-level keys are private to a layer, but referenced values are shared. That's the most surprising behavior in the model — a footgun for anyone coming from PSGI/Plack (where `$env` is one shared hashref mutated in place) — and it was almost entirely undocumented.

## Approach

The normative spec stays terse; the teaching material lives with the guides, at the right depth for each audience.

- **`Spec.pod` (Middleware)** — trimmed to the minimum: *why* (downward-only isolation) and *how* (shallow clone; top-level keys private, referenced values shared), then links to `PAGI::Building`. Drops the footgun framing, PSGI comparison, and jailbreak walkthrough that don't belong in a normative spec.
- **`PAGI::Building` (MIDDLEWARE)** — the authoritative deep-dive: why shallow and not deep (deep clone would sever the shared `pagi.connection`/`state` and break the escape hatch), the scalar-doesn't-propagate footgun, and how to share state across layers (reference seeded high, up/down directionality, `PAGI::Stash`). Also fixes the `with_request_id` example, which mutated `$scope` in place against the very rule.
- **`PAGI::PSGI`** — a short migrant note: `$env` was shared/mutated; scope is cloned and isolated; share through a reference.
- **`PAGI::Tutorial` (2.9 Pitfalls)** — a one-paragraph "a scope key set in middleware vanishes" note pointing at `PAGI::Building`.

## Scope

Docs-only across four PODs. `podchecker` clean on all four; cross-link anchors verified. No normative behavior change — it documents existing behavior (and corrects one example that contradicted it).

## Parked follow-up (not in this PR)

Separately: the spec declares "no response was started" an observer-independent fact and points at the `pagi.connection` object, but that object's interface defines no `response_started`/`response_complete` accessor — which is why tooling fell back to a clone-fragile `pagi.response.sent` scalar. Adding that accessor to `pagi.connection` is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)