### PR TITLE
Spec: response_started includes a server-synthesized backstop response

### DIFF
--- a/lib/PAGI/Spec/Www.pod
+++ b/lib/PAGI/Spec/Www.pod
@@ -784,11 +784,11 @@ short-circuited the request, or a B<server-synthesized error/backstop response>
 (e.g. the C<500> the server emits when the application produces nothing -- see
 L</Application Produced No Response>). Read-only to the application.
 
-To distinguish a response your application produced from one the server
-synthesized, use the connection's clean-vs-abnormal signal -- C<on_complete> fires
-for a clean finish, C<on_disconnect($reason)> for an abnormal end such as
-C<'server_error'> -- not C<response_started>, which only reports that I<some>
-response started.
+C<response_started> does not identify which producer started the response; an
+application response and a server-synthesized backstop set it alike. The
+clean-versus-abnormal outcome is reported separately by the request's terminal
+signal -- C<on_complete> on a clean finish, C<on_disconnect> with
+C<disconnect_reason> C<'server_error'> on a server backstop.
 
     my $started = $conn->response_started;  # Boolean, synchronous
 

--- a/lib/PAGI/Spec/Www.pod
+++ b/lib/PAGI/Spec/Www.pod
@@ -778,9 +778,17 @@ If registered after disconnect already occurred, the callback is invoked immedia
 
 B<C<response_started()>> - Returns true once B<this request's> response has started
 -- that is, once C<http.response.start> has been emitted for this scope -- and false
-before. The server sets it when it processes the response-start event, so it is true
-no matter who produced the response: the application, a framework, or a middleware
-that short-circuited the request. Read-only to the application.
+before. The server sets it when it processes the response-start event, so it is true no
+matter who produced the response: the application, a framework, a middleware that
+short-circuited the request, or a B<server-synthesized error/backstop response>
+(e.g. the C<500> the server emits when the application produces nothing -- see
+L</Application Produced No Response>). Read-only to the application.
+
+To distinguish a response your application produced from one the server
+synthesized, use the connection's clean-vs-abnormal signal -- C<on_complete> fires
+for a clean finish, C<on_disconnect($reason)> for an abnormal end such as
+C<'server_error'> -- not C<response_started>, which only reports that I<some>
+response started.
 
     my $started = $conn->response_started;  # Boolean, synchronous
 


### PR DESCRIPTION
Clarifies the `response_started` accessor: the server's own synthesized error/backstop response (the 500 it emits when the app produces nothing) also sets `response_started` — matching the implementation and the canonical ASGI server (uvicorn sends its 500 through the same path, flipping the flag). Adds a note that `disconnect_reason`/`on_complete` vs `on_disconnect('server_error')` is the right tool to tell a clean app response from a backstop.

Part of the response_started-on-pagi.connection work (PAGI-Server + PAGI-Tools PRs separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)