### PR TITLE
spec(www): add sse.close send-event

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,13 @@
   - Middleware section: clarified that middleware propagate the inner Future
     (not a value) and observe/rewrite responses by wrapping $send/$receive;
     removed a stranded comment from the example.
+  - Added the sse.close send-event: an explicit, application-initiated end to an
+    SSE stream (the SSE analog of http.response.body{more=>0}), ending it
+    immediately and decoupled from the application returning. Optional reason
+    field is server-side metadata only -- never transmitted to the client (SSE
+    has no close frame, unlike websocket.close). After sse.close, further
+    sse.send/sse.comment/sse.keepalive MUST raise; sse.close is idempotent.
+    Returning after the final sse.send remains a valid way to end a stream.
 
   [Documentation]
   - Tutorial: new Part 2 section "2.8 Middleware: Wrapping an Application"

--- a/Changes
+++ b/Changes
@@ -19,6 +19,9 @@
     Returning after the final sse.send remains a valid way to end a stream.
 
   [Documentation]
+  - Cookbook: new SERVER-SENT EVENTS recipe "Ending a stream: return vs
+    sse.close" -- the two termination paths (identical on the wire), the
+    server-side-only reason, and observing close events by wrapping $send.
   - Tutorial: new Part 2 section "2.8 Middleware: Wrapping an Application"
     teaching the pure $app -> $app pattern (scope cloning, wrapping
     $send/$receive, short-circuiting, error propagation, the inert return

--- a/lib/PAGI/Cookbook.pod
+++ b/lib/PAGI/Cookbook.pod
@@ -387,6 +387,60 @@ you stop when the client closes:
 Using C<< Future::IO->sleep >> rather than C<sleep> keeps the handler
 non-blocking and loop-agnostic.
 
+=head2 Ending a stream: return vs C<sse.close>
+
+A stream ends in one of two ways, and they are B<identical on the wire> -- the
+server writes the end-of-stream marker and closes; the client cannot tell them
+apart. B<Return> after the final C<sse.send> and the server ends the stream when
+your handler's Future resolves:
+
+    for my $msg (@events) {
+        await $send->({ type => 'sse.send', %$msg });
+    }
+    return;   # server flushes buffered events and closes
+
+Or end it B<explicitly> with C<sse.close>. This ends the stream B<immediately --
+before the handler returns> -- so a helper deep in the call stack can stop the
+stream in place, and you can attach a server-side C<reason> for your logs and
+metrics. The C<reason> is never sent to the client (SSE has no close frame):
+
+    async sub stream_until_done {
+        my ($send, $source) = @_;
+        while (my $item = await $source->next) {
+            return await $send->({ type => 'sse.close', reason => 'source_error' })
+                if $item->{fatal};
+            await $send->({ type => 'sse.send', data => $item->{data} });
+        }
+        await $send->({ type => 'sse.close', reason => 'source_drained' });
+    }
+
+After C<sse.close>, any further C<sse.send>/C<sse.comment>/C<sse.keepalive>
+raises, and a second C<sse.close> is a no-op. To tell the I<client> anything --
+including "stop reconnecting" -- send an ordinary C<sse.send> event before
+closing (and answer the client's next connection with HTTP C<204>); C<reason> is
+for the server side only.
+
+Because the close is an event on C<$send>, middleware can observe it. Wrap
+C<$send> to fan close reasons out to metrics or tracing without touching the
+application:
+
+    sub observe_sse_closes {
+        my ($app) = @_;
+        return async sub {
+            my ($scope, $receive, $send) = @_;
+            my $wrapped = async sub {
+                my ($event) = @_;
+                metric_inc('sse_close', { reason => $event->{reason} // 'unspecified' })
+                    if ($event->{type} // '') eq 'sse.close';
+                return await $send->($event);   # forward unchanged
+            };
+            await $app->($scope, $receive, $wrapped);
+        };
+    }
+
+An auto-close-on-return stream has no event to intercept, so it cannot be
+observed this way. See L<PAGI::Spec::Www/"Close SSE - C<send> event">.
+
 =head1 FLOW CONTROL
 
 =head2 Keeping a slow client current instead of stale

--- a/lib/PAGI/Spec/Www.pod
+++ b/lib/PAGI/Spec/Www.pod
@@ -1761,6 +1761,35 @@ Unlike C<websocket.close>, C<sse.close> carries B<no> code or client-visible
 reason: WebSocket has an RFC 6455 close frame to carry them, while SSE has no such
 frame on the wire.
 
+B<Return vs C<sse.close>.> Both terminate the stream and are B<identical on the
+wire>: the server writes the end-of-stream marker (the chunked terminator over
+HTTP/1.1, C<END_STREAM> over HTTP/2) and closes the stream. A client cannot tell
+which path was taken -- C<sse.close> adds nothing to the wire, since its C<reason>
+never leaves the server. They differ only in who signals the end, when, and with
+what server-side metadata:
+
+=over
+
+=item -
+
+B<Return> sends no end-event: the server infers completion from the application's
+returned Future resolving and tears the stream down then. The end is tied to the
+application returning.
+
+=item -
+
+B<C<sse.close>> is an explicit C<send> event: the server tears the stream down
+B<immediately> on receipt, B<before> the application returns. This lets a helper
+deep in the call stack end the stream in place (without unwinding to a return),
+frees the client's connection ahead of any slow post-close cleanup the application
+still has to perform, and records the C<reason> for the server's access log. After
+C<sse.close>, further sends raise (see above) and a subsequent return is a no-op.
+
+=back
+
+When the application's final act is its last C<sse.send> immediately followed by a
+return, the two paths are equivalent apart from the server-side C<reason>.
+
 =head3 SSE Disconnect - C<receive> event
 
 Sent to the application if the client disconnects or if the server shuts down the SSE stream after C<sse.start>.

--- a/lib/PAGI/Spec/Www.pod
+++ b/lib/PAGI/Spec/Www.pod
@@ -1645,7 +1645,10 @@ C<data> is the one field that legitimately contains newlines: the server splits 
 on newlines and emits one C<data:> line per segment, preserving multi-line
 payloads.
 
-To end the SSE stream the application simply returns after the final C<sse.send>. The server will flush buffered events and close the HTTP connection.
+To end the SSE stream the application either returns after its final C<sse.send>,
+or sends C<sse.close> explicitly (see L</Close SSE - C<send> event>). On return the
+server flushes buffered events and closes the HTTP connection; C<sse.close> does
+the same immediately, decoupled from the application returning.
 
 =head3 SSE Comment - C<send> event
 
@@ -1719,6 +1722,44 @@ B<Example:>
         interval => 30,
         comment  => 'ping',
     });
+
+=head3 Close SSE - C<send> event
+
+C<sse.close> ends the SSE stream explicitly. It is the SSE analog of
+C<http.response.body> with C<<< more => 0 >>>: the server flushes any buffered
+events, writes the end-of-stream marker, and closes the stream. An application
+B<may> end a stream either by returning after its final C<sse.send> or by sending
+C<sse.close>; the latter is the explicit form and ends the stream B<immediately>,
+decoupled from the application returning -- which lets a helper deep in the call
+stack end the stream without unwinding to the top.
+
+=over
+
+=item -
+
+C<type> -- C<"sse.close">
+
+=item -
+
+C<reason> (String, optional) -- A server-side reason for logging, metrics, or
+tracing (for example C<"job_complete">). The SSE wire protocol has no close frame,
+so C<reason> is B<never transmitted to the client>; it is server-side metadata
+only, surfaced through the same channels as the C<sse.disconnect> reason. To convey
+anything to the client -- including "stop reconnecting" -- send an ordinary
+C<sse.send> event before closing and use an HTTP C<204> (or C<retry:>) on the
+client's next connection.
+
+=back
+
+After C<sse.close>, any further C<sse.send>, C<sse.comment>, or C<sse.keepalive>
+on the same connection B<MUST> raise -- the stream is closed. C<sse.close> is
+B<idempotent>: a second C<sse.close> is ignored. C<sse.close> does not by itself
+stop the client reconnecting; that is governed by the response to the client's
+next connection, not by the close of the current stream.
+
+Unlike C<websocket.close>, C<sse.close> carries B<no> code or client-visible
+reason: WebSocket has an RFC 6455 close frame to carry them, while SSE has no such
+frame on the wire.
 
 =head3 SSE Disconnect - C<receive> event
 


### PR DESCRIPTION
## What

Adds **`sse.close`** to the PAGI SSE protocol: an explicit, application-initiated `$send` event that ends an SSE stream immediately, decoupled from the application returning.

## Why

SSE was the **only** PAGI connection type whose termination wasn't a `$send` event:
- HTTP ends via `http.response.body{more => 0}`
- WebSocket ends via `websocket.close`
- even ASGI's (non-first-class) SSE ends via `more_body: false`
- **SSE** — could only end by *returning*

That made "close from a helper, decoupled from return" impossible and forced frameworks to fake a close (the root of the muddy `PAGI::SSE::close()` semantics). `sse.close` makes SSE consistent with its siblings.

## Shape (the key decisions)

`sse.close` is the SSE analog of `http.response.body{more=>0}` — **not** of `websocket.close{code,reason}`:
- **Reason-free on the wire.** SSE has no close frame; `EventSource` cannot observe a close code/reason. The optional `reason` field is **server-side metadata only** (logging/metrics/tracing), never transmitted — symmetric with the existing `sse.disconnect` reason.
- **Explicit, not mandatory.** Returning after the final `sse.send` remains valid; `sse.close` is the explicit form that ends *now*.
- **After `sse.close`, further `sse.send`/`sse.comment`/`sse.keepalive` MUST raise.** `sse.close` is idempotent.
- Stop-reconnect stays an application concern (sentinel event + `204`/`retry:`), not part of `sse.close`.

This is the spec half of a three-repo change (PAGI → PAGI-Server → PAGI-Tools). Server enforcement (dispatch, teardown, send-after-close raising) and framework wiring (`PAGI::SSE::close()`) follow in PAGI-Server and PAGI-Tools PRs. `sse.disconnect`-on-server-shutdown already in the spec; no change needed here.

Design background: 6-expert panel research (summarized in the PAGI-Tools design docs).

## Changes
- `lib/PAGI/Spec/Www.pod` — new `=head3 Close SSE - send event`; amended the "return to end" paragraph under `sse.send`.
- `Changes` — `0.002001` entry.
- `podchecker` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)