### PR TITLE
spec(www): add sse.http.response.* (decline an SSE request)

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,14 @@
     has no close frame, unlike websocket.close). After sse.close, further
     sse.send/sse.comment/sse.keepalive MUST raise; sse.close is idempotent.
     Returning after the final sse.send remains a valid way to end a stream.
+  - Added sse.http.response.start / sse.http.response.body send-events: before
+    sse.start, an application MAY decline the stream and return a normal HTTP
+    response (404, 401, a 204 to stop EventSource reconnection, a redirect, ...).
+    Namespaced under sse. (mirroring the websocket.http.response denial events) so
+    an sse scope only carries sse.* events. First-send-wins: after sse.start these
+    are invalid; after sse.http.response.start the stream events are invalid (both
+    MUST raise). Unlike the WebSocket denial extension this is a core capability
+    (no event-stream fallback exists), so every conforming server MUST support it.
 
   [Documentation]
   - Cookbook: new SERVER-SENT EVENTS recipe "Ending a stream: return vs

--- a/lib/PAGI/Spec/Www.pod
+++ b/lib/PAGI/Spec/Www.pod
@@ -1607,6 +1607,66 @@ sends C<Connection: keep-alive> and frames the stream with chunked
 C<Transfer-Encoding>; HTTP/2 multiplexes and DATA-frames the stream, so those
 connection-specific headers do not apply. Applications need not set any of these.
 
+=head3 Decline SSE - C<send> event
+
+An C<sse> request is an ordinary HTTP C<GET> with C<Accept: text/event-stream>;
+the server classifies it as an C<sse> scope before the application runs. Instead
+of starting an event stream, an application B<may> decline and return a normal
+HTTP response -- a C<404> for an unknown endpoint, a C<401>/C<403> for an
+unauthenticated request, a C<204> to tell an C<EventSource> client to stop
+reconnecting, a redirect, and so on. It sends two events B<in place of>
+C<sse.start>, valid only before the stream has started:
+
+=over
+
+=item -
+
+B<C<sse.http.response.start>> -- C<{ status (Int), headers (ArrayRef[ArrayRef[Bytes]]) }>,
+structured exactly like C<http.response.start>.
+
+=item -
+
+B<C<sse.http.response.body>> -- C<{ body (Bytes, default ""), more (Int, default 0) }>,
+structured exactly like C<http.response.body>; set C<<< more => 1 >>> to send the
+body in multiple events.
+
+=back
+
+These events are namespaced under C<sse.> -- mirroring the
+C<websocket.http.response> denial events -- so that an C<sse> scope only ever
+carries C<sse.*> events, keeping the server's per-scope dispatch and any
+event-type-aware middleware scope-separated.
+
+The server sends the resulting HTTP response and closes the connection; no event
+stream is started and no C<sse.disconnect> is delivered. This is a
+B<first-send-wins> choice: after C<sse.start>, C<sse.http.response.*> events are
+invalid and MUST raise; after C<sse.http.response.start>, the stream events
+(C<sse.send> / C<sse.comment> / C<sse.keepalive> / C<sse.close>) are invalid and
+MUST raise.
+
+Unlike the WebSocket denial response -- an optional extension with a
+C<websocket.close> fallback -- declining an SSE request is a B<core> capability:
+there is no event-stream fallback, so every conforming server MUST support it.
+
+    # Decline an unauthenticated SSE request with a 401 instead of streaming:
+    if (!authorized($scope)) {
+        await $send->({
+            type    => 'sse.http.response.start',
+            status  => 401,
+            headers => [
+                [ 'content-type',     'text/plain' ],
+                [ 'www-authenticate', 'Bearer' ],
+            ],
+        });
+        await $send->({ type => 'sse.http.response.body', body => 'Unauthorized' });
+        return;
+    }
+    await $send->({ type => 'sse.start', status => 200 });
+
+A C<204 No Content> (or any non-C<200>) response is the supported way to stop an
+C<EventSource> client's reconnection loop: the client treats it as a terminal
+failure and does not reconnect.
+
 =head3 Send SSE - C<send> event
 
 C<sse.send> emits a single SSE dispatch. Fields marked "String" are Unicode strings per the core data-type rules and MUST be UTF-8 encoded by the server before transmission.


### PR DESCRIPTION
## What

Adds **`sse.http.response.start`** / **`sse.http.response.body`** to the SSE protocol: before `sse.start`, an application MAY send these *in place of* `sse.start` to **decline the stream and return a normal HTTP response** — `404` (unknown endpoint), `401`/`403` (auth), **`204` to stop `EventSource` reconnection**, redirects, etc.

## Why

An SSE request is a plain `GET` with `Accept: text/event-stream` that the server pre-classifies as an `sse` scope. Today that scope only accepts `sse.*` events, so there's **no way to return a non-SSE response** — and App::Router's SSE 404 actually **crashes** the server (`"unrecognized event type 'http.response.start' for sse protocol"`). This also finally makes the `204`-stop-reconnect mechanism (flagged during the `sse.close` work) expressible.

## Shape — namespaced (`sse.http.response.*`), not plain `http.response.*`

Mirrors the existing `websocket.http.response.*` denial events, so an `sse` scope **only ever carries `sse.*` events**. This was a close call settled by a **four-lens design panel** (ASGI lineage, internal-consistency code audit, naming design, implementation) — **3 of 4 for the namespaced form**. The decisive reason: **the prefix is the per-scope state-machine dispatch key.** ASGI/Uvicorn *raise* on a plain `http.response.start` over a `websocket` scope for exactly this reason; PAGI's SSE handler is in the identical position, and PAGI already namespaced WS denial. Plain `http.response.*` on an `sse` scope would couple the two state machines and silently misroute through `http.*`-keyed middleware.

(The dissent's real point — a decline *is* an HTTP response, so it'd be nice for HTTP middleware to see it — is addressable at the middleware layer; it doesn't justify coupling the server's per-scope dispatch.)

## Semantics
- **First-send-wins:** after `sse.start`, `sse.http.response.*` MUST raise; after `sse.http.response.start`, the stream events (`sse.send`/`comment`/`keepalive`/`close`) MUST raise.
- **Core, not an extension:** unlike WS denial (which falls back to `websocket.close`), SSE has **no** event-stream fallback, so every conforming server MUST support it.

Spec PR first (this), then PAGI-Server (`sse.http.response.*` dispatch, HTTP/1.1 + HTTP/2, mirroring the WS-denial code) → App::Router (scope-aware decline; fixes the SSE *and* WS 404 crash) + cross-repo test. `podchecker` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)