### PR TITLE
spec: define application loading and send completion

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,15 @@
 # This file documents the revision history for Perl extension PAGI
 
+Unreleased
+  [Specification clarifications]
+  - Centralized the $send Future contract: successful resolution means the
+    server has finished consuming the event and any tied application resource,
+    and accepted its output for outbound processing; it does not mean client
+    receipt or complete-response delivery. Before close, validation and
+    resource failures fail the Future; post-close sends are successful no-ops,
+    and pending send Futures carry transport-independent backpressure even
+    without optional pagi.transport introspection.
+
 0.002001 - 2026-06-30
   [Specification updates]
   - Application/middleware return value is now specified as inert: the server
@@ -467,5 +477,3 @@
 
 0.001001 - 2025-12-17
   - Placeholder release
-
-

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 # This file documents the revision history for Perl extension PAGI
 
-Unreleased
+0.002002 - 2026-08-21
   [Specification clarifications]
   - Centralized the $send Future contract: successful resolution means the
     server has finished consuming the event and any tied application resource,

--- a/Changes
+++ b/Changes
@@ -1,5 +1,19 @@
 # This file documents the revision history for Perl extension PAGI
 
+Unreleased
+  [Specification 0.4 Draft]
+  - Distinguished the canonical runtime PAGI code reference from an
+    application-provider object. General-purpose runners should accept either;
+    each loaded provider instance is normalized exactly once through to_app
+    before dispatch, and only the resulting code reference crosses the runtime
+    boundary.
+  - Lifecycle handling remains part of the lifespan protocol and is not
+    inferred by PAGI from methods on application-provider objects; deployment
+    tools remain free to define their own non-protocol hooks.
+  - Revised PAGI::Spec::Server to version 0.2. PAGI no longer prescribes a
+    new(app => ...) constructor or run method for conforming servers; server
+    construction and plugin compatibility belong to runner-specific APIs.
+
 0.002001 - 2026-06-30
   [Specification updates]
   - Application/middleware return value is now specified as inert: the server
@@ -467,5 +481,3 @@
 
 0.001001 - 2025-12-17
   - Placeholder release
-
-

--- a/Changes
+++ b/Changes
@@ -10,6 +10,10 @@ Unreleased
   - Lifecycle handling remains part of the lifespan protocol and is not
     inferred by PAGI from methods on application-provider objects; deployment
     tools remain free to define their own non-protocol hooks.
+  - Core and protocol versions now explicitly evolve independently. An omitted
+    pagi.spec_version uses the default owned by the applicable protocol rather
+    than the core version; WWW and Lifespan both use 0.1 as their conservative
+    compatibility default.
   - Revised PAGI::Spec::Server to version 0.2. PAGI no longer prescribes a
     new(app => ...) constructor or run method for conforming servers; server
     construction and plugin compatibility belong to runner-specific APIs.

--- a/Changes
+++ b/Changes
@@ -3,10 +3,11 @@
 0.002002 - 2026-08-21
   [Specification 0.4 Draft]
   - Distinguished the canonical runtime PAGI code reference from an
-    application-provider object. General-purpose runners should accept either;
-    each loaded provider instance is normalized exactly once through to_app
-    before dispatch, and only the resulting code reference crosses the runtime
-    boundary.
+    already-instantiated application-provider object. General-purpose runners
+    should accept either; package-name strings and class-method to_app dispatch
+    are not provider forms. Each loaded provider instance is normalized exactly
+    once before dispatch, and only the resulting code reference crosses the
+    runtime boundary.
   - Lifecycle handling remains part of the lifespan protocol and is not
     inferred by PAGI from methods on application-provider objects; deployment
     tools remain free to define their own non-protocol hooks.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ specification without pulling in a particular server or toolkit:
 - **PAGI** (this repository) — the specification, tutorial, cookbook, and
   example applications.
 - **PAGI-Server** — the reference server: HTTP/1.1, HTTP/2, WebSocket, SSE, TLS,
-  multi-worker, and the `pagi-server` CLI. Any server implementing the contract
-  in `PAGI::Spec::Server` is a drop-in alternative.
+  multi-worker, and the `pagi-server` CLI. `PAGI::Spec::Server` documents
+  application-loading and runtime integration; server plugin compatibility is
+  defined by each runner.
 - **PAGI-Tools** — the application toolkit: middleware, ready-made apps, the
   endpoint/router framework, request/response helpers, and `PAGI::App::WrapPSGI`.
 

--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ license = Artistic_2_0
 copyright_holder = John Napiorkowski
 copyright_year   = 2026
 abstract = The PAGI specification - Perl Asynchronous Gateway Interface
-version = 0.002001
+version = 0.002002
 
 [@Basic]
 [MetaJSON]

--- a/lib/PAGI.pm
+++ b/lib/PAGI.pm
@@ -147,9 +147,9 @@ L</INSTALLATION AND BACKWARD COMPATIBILITY>).
 The reference server (L<PAGI::Server>): an L<IO::Async>-based implementation
 supporting HTTP/1.1, HTTP/2, WebSocket, SSE, TLS, and multi-worker pre-forking,
 validated against L<PAGI::Server::Compliance>. Provides the C<pagi-server> CLI
-and L<PAGI::Server::Runner> (the C<-s CLASS> swappable-server runner behind
-C<pagi-server>). Any server implementing the contract in L<PAGI::Spec::Server>
-is a drop-in alternative.
+and L<PAGI::Server::Runner>. L<PAGI::Spec::Server> documents the boundary
+between application loading and the runtime PAGI application; server selection
+and plugin compatibility are runner-specific APIs.
 
 =item C<PAGI-Tools>
 
@@ -351,7 +351,7 @@ requires L<Future::AsyncAwait>).
 
 =item L<PAGI::Spec::Extensions> - The server extension mechanism
 
-=item L<PAGI::Spec::Server> - The server runner contract for swappable servers
+=item L<PAGI::Spec::Server> - Server and application-runner integration guidance
 
 =item L<PAGI::Server> - Reference server (C<PAGI-Server> distribution)
 
@@ -391,4 +391,3 @@ John Napiorkowski E<lt>jjnapiork@cpan.orgE<gt>
 This software is licensed under the same terms as Perl itself.
 
 =cut
-

--- a/lib/PAGI.pm
+++ b/lib/PAGI.pm
@@ -3,7 +3,7 @@ package PAGI;
 use strict;
 use warnings;
 
-our $VERSION = '0.002001';
+our $VERSION = '0.002002';
 
 1;
 
@@ -391,4 +391,3 @@ John Napiorkowski E<lt>jjnapiork@cpan.orgE<gt>
 This software is licensed under the same terms as Perl itself.
 
 =cut
-

--- a/lib/PAGI/Spec.pod
+++ b/lib/PAGI/Spec.pod
@@ -309,6 +309,32 @@ C<$send>: Coderef taking an event hashref and returning a C<Future>
 
 Each application is called per-connection, and remains active until the connection closes and cleanup completes.
 
+=head3 Send Completion Contract
+
+Every call to C<$send> returns a Future. Successful resolution means the server
+has validated and finished consuming the event, including any
+application-owned resource whose lifetime is tied to that send, and has
+accepted the resulting output into its outbound processing path. The
+application may release such a resource after the Future resolves.
+
+Resolution does B<not> mean that bytes have reached the network socket, an
+intermediary, or the client. It also does not mean that the complete response
+has been delivered.
+
+A server MAY keep the Future pending to apply outbound flow control. Awaiting
+C<$send> is therefore the transport-independent mechanism by which an
+application self-paces; awaiting a pending send suspends the application
+coroutine, not the Perl thread. This contract applies whether or not the server
+provides the optional C<pagi.transport> introspection object described by the
+applicable protocol specification.
+
+Before the connection closes, event-validation and event-resource failures
+required by the applicable protocol specification MUST fail the returned
+Future. After the connection has closed, C<$send> instead returns a
+successfully resolved Future and performs no work: it neither delivers the
+event nor signals closure. Applications detect closure through the protocol's
+disconnect event and any applicable connection-state object.
+
 =head3 Application Completion Contract
 
 B<The application's returned Future represents request completion.> When this Future resolves, the server considers the response finished and may close the connection, write access logs, or handle the next request.
@@ -490,7 +516,8 @@ Applications receiving these events should immediately halt unnecessary work, op
 
 =head3 Error Handling
 
-Servers must raise exceptions if:
+Before the connection closes, a server MUST reject an outgoing event by
+returning a failed Future from C<$send> if:
 
 =over
 
@@ -508,11 +535,15 @@ The C<type> field is unrecognized
 
 =back
 
-Applications should do the same when receiving malformed events.
+Applications should reject malformed incoming events by failing their
+application Future.
 
 Extra fields in events B<must not> cause errors -- this supports forward-compatible upgrades.
 
-If C<$send> is called after the connection has closed, it is a no-op: it neither delivers data nor raises. Applications detect closure through the protocol's disconnect event (and, for HTTP, the C<pagi.connection> state object), not by inspecting the result of C<$send>.
+The post-close behaviour of C<$send> is defined in L</Send Completion
+Contract>: it is a successful no-op and does not report closure. Applications
+use the protocol's disconnect event and, for HTTP, the C<pagi.connection> state
+object instead.
 
 =head3 Extensions
 

--- a/lib/PAGI/Spec.pod
+++ b/lib/PAGI/Spec.pod
@@ -288,7 +288,7 @@ a native PAGI application code reference; or
 
 =item -
 
-an application-provider object that implements C<to_app>.
+an already-instantiated application-provider object that implements C<to_app>.
 
 =back
 
@@ -299,6 +299,13 @@ code reference. An exception from C<to_app>, or any other return value, is an
 application-loading failure and MUST be reported before the runner begins
 serving traffic. Reloading an application or constructing independent worker
 instances constitutes a new load; request and connection dispatch do not.
+
+In this convention, an application-provider object is an already-instantiated
+blessed reference. A package-name string is not an application provider, and a
+runner MUST NOT satisfy provider normalization by invoking C<to_app> as a class
+method. Deployment tooling MAY accept module or class names as its own
+discovery and configuration input, but it must first construct an object or
+obtain a native PAGI code reference before entering this normalization step.
 
 A value that is itself a code reference is already a native PAGI application,
 even if it is blessed. It MUST be used as the application without calling a

--- a/lib/PAGI/Spec.pod
+++ b/lib/PAGI/Spec.pod
@@ -9,7 +9,7 @@ PAGI::Spec - The base PAGI specification: application interface and core concept
 I<Note: code examples are illustrative; their style is a documentation
 convenience, not a requirement of the specification.>
 
-B<Version>: 0.3 (Draft)
+B<Version>: 0.4 (Draft)
 
 =head2 Introduction
 
@@ -101,7 +101,7 @@ C<pagi>: A hashref with at least:
 
 =item -
 
-C<version> -- the core PAGI specification version, e.g. C<'0.3'>
+C<version> -- the core PAGI specification version, e.g. C<'0.4'>
 
 =item -
 
@@ -131,7 +131,7 @@ C<version>: Signals the core PAGI specification version that governs scopes/even
 
 =item -
 
-C<spec_version>: Indicates the version for the specific protocol (such as HTTP or WebSocket). Servers may omit it, in which case applications should assume it matches C<version>.
+C<spec_version>: Indicates the version for the specific protocol (such as HTTP or WebSocket). Core and protocol versions are independent and need not be equal. Servers may omit C<spec_version> only when it is the same as C<version>; applications should assume equality when it is omitted.
 
 =item -
 
@@ -254,15 +254,54 @@ B<Note:> Booleans are intentionally omitted from the core spec to avoid ambiguit
 
 =head3 Applications
 
-PAGI applications are single coderefs returning Futures.
+At the server/application protocol boundary, a PAGI application is a single
+code reference that accepts C<($scope, $receive, $send)> and returns a Future.
+This is the only runtime application interface defined by PAGI.
 
-Applications may optionally support lifecycle hooks such as shutdown. If supported, the PAGI server should call:
+Application startup and shutdown are expressed through the lifespan protocol
+in L<PAGI::Spec::Lifespan>. Methods on an application-provider object are not
+PAGI lifecycle hooks. Deployment tooling may define its own provider hooks,
+but they do not replace or alter the PAGI lifespan protocol.
 
-    $app->on_shutdown(sub {
-        # Optional shutdown logic (e.g., flush logs, close DB)
-    });
+=head4 Application Providers and Loading
 
-This pattern is reserved and may be formalized in a future PAGI extension.
+PAGI defines the runtime application interface, not how deployment tooling
+discovers, configures, or constructs an application. To support applications
+that need configuration or retain construction metadata, a general-purpose
+application runner SHOULD accept both of these input forms:
+
+=over
+
+=item -
+
+a native PAGI application code reference; or
+
+=item -
+
+an application-provider object that implements C<to_app>.
+
+=back
+
+An application-provider object is not itself a PAGI application. A runner
+that accepts one MUST call C<to_app> exactly once per loaded provider instance,
+before using it for connection dispatch, and MUST verify that the result is a
+code reference. An exception from C<to_app>, or any other return value, is an
+application-loading failure and MUST be reported before the runner begins
+serving traffic. Reloading an application or constructing independent worker
+instances constitutes a new load; request and connection dispatch do not.
+
+A value that is itself a code reference is already a native PAGI application,
+even if it is blessed. It MUST be used as the application without calling a
+C<to_app> method it may also provide.
+
+A runner MUST NOT call C<to_app> once per request or connection. After
+normalization, the server, middleware, and all per-connection dispatch use only
+the resulting PAGI application code reference.
+
+File names, module names, command-line expressions, configuration formats,
+server construction, and runner plugin APIs are deployment-tool concerns and
+are outside this specification. See L<PAGI::Spec::Server> for integration
+guidance.
 
 Applications B<must> throw an exception if the incoming C<<< scope->{type} >>> is not supported. This prevents the server from assuming a protocol is handled when it is not, and avoids ambiguity in multi-protocol deployments.
 
@@ -540,6 +579,13 @@ Byte content (e.g., body payloads) must be passed as Perl scalars B<without> the
 
 =item -
 
+0.4 (Draft): Distinguished the runtime PAGI application from an
+application-provider object and canonized one-time-per-load C<to_app>
+normalization by general-purpose application runners. Lifecycle remains part
+of the lifespan protocol rather than an inferred provider-object hook.
+
+=item -
+
 0.3 (Draft): Removed C<pagi.features> (superseded by the C<extensions>
 mechanism). See L<PAGI::Spec::Www> for the HTTP/WebSocket/SSE 0.3 changes.
 
@@ -578,7 +624,7 @@ L<PAGI::Spec::Tls> - TLS connection information extension
 
 =item -
 
-L<PAGI::Spec::Server> - server runner contract for swappable servers
+L<PAGI::Spec::Server> - server and application-runner integration guidance
 
 =back
 

--- a/lib/PAGI/Spec.pod
+++ b/lib/PAGI/Spec.pod
@@ -95,7 +95,7 @@ C<type>: Protocol type, e.g., C<http>, C<websocket>
 
 =item -
 
-C<pagi>: A hashref with at least:
+C<pagi>: A hashref containing:
 
 =over
 
@@ -105,7 +105,9 @@ C<version> -- the core PAGI specification version, e.g. C<'0.4'>
 
 =item -
 
-C<spec_version> -- the protocol sub-spec version (optional; if omitted, assume it matches C<version>), e.g. C<'0.3'>
+C<spec_version> -- the protocol sub-spec version, e.g. C<'0.3'>. It may be
+omitted only as permitted by that protocol specification; if omitted, use the
+protocol's documented default.
 
 =back
 
@@ -127,11 +129,19 @@ Clarification on PAGI version keys:
 
 =item -
 
-C<version>: Signals the core PAGI specification version that governs scopes/events. This value B<must> be a string.
+C<version>: Signals the core PAGI specification version that governs the
+runtime application interface and core semantics. This value B<must> be a
+string.
 
 =item -
 
-C<spec_version>: Indicates the version for the specific protocol (such as HTTP or WebSocket). Core and protocol versions are independent and need not be equal. Servers may omit C<spec_version> only when it is the same as C<version>; applications should assume equality when it is omitted.
+C<spec_version>: Indicates the version for the specific protocol (such as HTTP
+or WebSocket). Core and protocol versions are independent and need not be
+equal. Each protocol specification MUST define the version represented by an
+omitted C<spec_version>. Applications MUST use that protocol-defined default
+and MUST NOT infer it from C<version>. A server that omits C<spec_version> is
+declaring only the protocol-defined default and MUST NOT use behaviour
+introduced by a later protocol version on that connection.
 
 =item -
 
@@ -582,7 +592,9 @@ Byte content (e.g., body payloads) must be passed as Perl scalars B<without> the
 0.4 (Draft): Distinguished the runtime PAGI application from an
 application-provider object and canonized one-time-per-load C<to_app>
 normalization by general-purpose application runners. Lifecycle remains part
-of the lifespan protocol rather than an inferred provider-object hook.
+of the lifespan protocol rather than an inferred provider-object hook. Core
+and protocol versions evolve independently; each protocol now owns the
+compatibility default for an omitted C<spec_version>.
 
 =item -
 

--- a/lib/PAGI/Spec/Lifespan.pod
+++ b/lib/PAGI/Spec/Lifespan.pod
@@ -99,7 +99,12 @@ The C<version> key of the C<pagi> hashref (accessed as C<< $scope->{pagi}{versio
 
 =item -
 
-The C<spec_version> key of the C<pagi> hashref (accessed as C<< $scope->{pagi}{spec_version} >>) (String) - The version of this lifespan sub-specification. Optional; if missing, assume it matches C<version>.
+The C<spec_version> key of the C<pagi> hashref (accessed as
+C<< $scope->{pagi}{spec_version} >>) (String) - The version of this lifespan
+sub-specification. Optional; if missing, applications MUST assume C<'0.1'>.
+Omitting it declares support for version 0.1 only, so the server MUST NOT use
+behaviour introduced by a later lifespan version. The core PAGI C<version>
+does not affect this default.
 
 =item -
 

--- a/lib/PAGI/Spec/Server.pod
+++ b/lib/PAGI/Spec/Server.pod
@@ -29,8 +29,8 @@ any particular event-loop ownership model.
 The canonical runtime application is always a code reference accepting
 C<($scope, $receive, $send)> and returning a Future. As described in
 L<PAGI::Spec/Application Providers and Loading>, a general-purpose application
-runner SHOULD also accept an application-provider object implementing
-C<to_app>.
+runner SHOULD also accept an already-instantiated application-provider object
+implementing C<to_app>.
 
 When given a provider object, the runner MUST call C<to_app> exactly once per
 loaded provider instance, verify that it returned a code reference, and pass
@@ -39,6 +39,12 @@ Provider construction failures and invalid C<to_app> return values are loading
 errors; they MUST be reported before the runner starts serving traffic. A
 native code reference takes precedence over provider-method detection, even if
 that code reference is blessed.
+
+A package-name string is not an application-provider object, and this
+convention does not permit invoking C<to_app> as a class method. A runner MAY
+accept module or class names through its implementation-specific discovery
+interface, but that discovery step must produce an instantiated provider object
+or a native PAGI code reference before normalization begins.
 
 =head2 Server Construction
 

--- a/lib/PAGI/Spec/Server.pod
+++ b/lib/PAGI/Spec/Server.pod
@@ -2,118 +2,106 @@
 
 =head1 NAME
 
-PAGI::Spec::Server - The PAGI server runner contract for swappable servers
+PAGI::Spec::Server - PAGI server and application-runner integration guidance
 
-=head1 PAGI Server Runner Contract
+=head1 PAGI Server and Application-Runner Integration
 
-B<Version>: 0.1 (Draft)
+B<Version>: 0.2 (Draft)
 
-This document specifies the interface a PAGI server class implements so
-that application runners (L<PAGI::Server::Runner>'s C<-s CLASS> option, deployment
-tooling, etc.) can construct and start it without server-specific
-knowledge. It is the server-side counterpart of the application
-interface described in L<the main specification|PAGI::Spec>.
+The main specification, L<PAGI::Spec>, defines the runtime boundary between a
+PAGI server and application. This document clarifies how deployment tooling
+reaches that boundary without prescribing a Perl object model for servers.
 
-A PAGI server is any code that accepts PAGI applications and speaks the
-protocol in L<the main specification|PAGI::Spec>. Implementing this
-contract is OPTIONAL but RECOMMENDED for any server that wishes to be
-usable as a drop-in replacement with C<PAGI::Server::Runner> or compatible
-runners.
+=head2 Runtime Boundary
 
-=head2 Constructor
+A PAGI server invokes a normalized PAGI application code reference and speaks
+the scopes and events defined by the PAGI protocol specifications. Conformance
+is determined by that runtime behaviour, not by how the server is constructed
+or started.
 
-A conforming server class MUST provide a C<new> class method accepting a
-hash of options:
+A server may be exposed as a class, a function, an embedded service, an
+external process, or another implementation-specific interface. PAGI does not
+require a C<new> constructor, a C<app> constructor option, a C<run> method, or
+any particular event-loop ownership model.
 
-    my $server = My::PAGI::Server->new(%options);
+=head2 Application Loading and Normalization
 
-A runner passes the following common options. A conforming server MUST
-accept these (it MAY ignore ones that do not apply, but MUST NOT die on
-them):
+The canonical runtime application is always a code reference accepting
+C<($scope, $receive, $send)> and returning a Future. As described in
+L<PAGI::Spec/Application Providers and Loading>, a general-purpose application
+runner SHOULD also accept an application-provider object implementing
+C<to_app>.
 
-=over
+When given a provider object, the runner MUST call C<to_app> exactly once per
+loaded provider instance, verify that it returned a code reference, and pass
+only that normalized code reference across the server/application boundary.
+Provider construction failures and invalid C<to_app> return values are loading
+errors; they MUST be reported before the runner starts serving traffic. A
+native code reference takes precedence over provider-method detection, even if
+that code reference is blessed.
 
-=item -
+=head2 Server Construction
 
-C<app> (code reference, required) - the PAGI application.
+The mechanism by which a runner configures and starts a server is an API of
+that runner and server implementation, not part of PAGI conformance. A runner
+may offer server-class selection, constructor options, command-line switches,
+or plugin contracts, but other conforming runners and servers need not use the
+same conventions.
 
-=item -
+For example, L<PAGI::Server::Runner> currently constructs the reference
+L<PAGI::Server> and offers a C<-s CLASS> extension point. Those interfaces are
+documented by the C<PAGI-Server> distribution; they are not required of every
+PAGI server.
 
-C<host> (string) - interface to bind. Runners supply a default
-(C<PAGI::Server::Runner> uses C<127.0.0.1>) when no other binding option is given.
+=head2 Runner Guidance
 
-=item -
-
-C<port> (integer) - TCP port to bind. Runner default: C<5000>.
-
-=item -
-
-C<quiet> (boolean) - suppress startup banners and informational output.
-
-=item -
-
-C<access_log> (filehandle or undef) - where to write access logs; an
-explicit undef disables access logging. When the option is absent the
-server chooses its own default.
-
-=item -
-
-C<loop_type> (string) - event loop implementation hint. Servers not
-offering a choice of loop MAY ignore it.
-
-=back
-
-Any further options are server-specific. They are collected by the
-server's own CLI wrapper (for C<PAGI::Server>, C<bin/pagi-server>) and
-passed through the runner's C<server_options> mechanism verbatim. A
-conforming server SHOULD reject options it does not recognize as
-either common options (listed above) or its own documented
-server-specific options, with a clear error naming the option.
-
-=head2 run
-
-A conforming server class MUST provide a C<run> instance method:
-
-    $server->run;
-
-C<run> blocks the calling process, owns the event loop, and returns (or
-exits) only when the server has shut down. Signal handling, worker
-management, and graceful-shutdown behaviour are server-specific.
-
-Runners MUST NOT place critical cleanup logic in code that follows
-C<run>, since a conforming server MAY terminate the process directly
-instead of returning; runners should register cleanup with Perl's C<END>
-mechanism or equivalent.
-
-=head2 Runner conventions
-
-Application runners that construct servers by class name SHOULD:
+A general-purpose runner should keep loading and runtime responsibilities
+separate:
 
 =over
 
 =item -
 
-accept the class via a C<-s>/C<--server CLASS> style option, defaulting
-to C<PAGI::Server>;
+discover and construct the configured application or provider;
 
 =item -
 
-load the class, call C<new> with the options above plus any
-server-specific passthrough options, then call C<run>;
+normalize a provider through C<to_app> before using it for connection
+dispatch;
 
 =item -
 
-treat C<run> as blocking and perform daemonization, PID files, and
-privilege dropping before calling it.
+configure and start the selected server through its implementation-specific
+API; and
+
+=item -
+
+use only the normalized application code reference for per-connection
+dispatch.
 
 =back
 
-See L<PAGI::Server::Runner> for the reference runner implementation and
-L<PAGI::Server> for the reference server.
+Loading errors should identify whether discovery, provider construction,
+C<to_app>, or return-value validation failed.
+
+=head2 Portability
+
+A native PAGI application code reference is portable across conforming PAGI
+servers and runners. An application-provider object is portable across runners
+that adopt the C<to_app> loading convention. Whether one server implementation
+can be selected as a drop-in replacement for another depends on the runner's
+plugin API and is not guaranteed by the PAGI runtime specification.
 
 =head2 Version History
 
 =over
+
+=item -
+
+0.2 (Draft): Removed the prescribed C<new(app =E<gt> ...)> and C<run>
+server-class contract. Clarified the separation between the runtime PAGI
+application, one-time application-provider normalization, and
+implementation-specific server construction.
 
 =item -
 

--- a/lib/PAGI/Spec/Www.pod
+++ b/lib/PAGI/Spec/Www.pod
@@ -313,11 +313,11 @@ C<type> (String) -- C<"http">
 
 =item -
 
-C<< $scope->{pagi}{version} >> (String) -- The PAGI core spec version (e.g. C<'0.3'>)
+C<< $scope->{pagi}{version} >> (String) -- The PAGI core spec version (e.g. C<'0.4'>)
 
 =item -
 
-C<< $scope->{pagi}{spec_version} >> (String) -- The version of this HTTP sub-specification (optional; if omitted, assume it matches C<version>)
+C<< $scope->{pagi}{spec_version} >> (String) -- The version of this HTTP sub-specification (e.g. C<'0.3'>; optional only when it matches C<version>)
 
 =item -
 
@@ -1110,11 +1110,11 @@ C<type> (String) -- C<"websocket">
 
 =item -
 
-C<< $scope->{pagi}{version} >> (String) -- The PAGI core spec version (e.g. C<'0.3'>)
+C<< $scope->{pagi}{version} >> (String) -- The PAGI core spec version (e.g. C<'0.4'>)
 
 =item -
 
-C<< $scope->{pagi}{spec_version} >> (String) -- The version of this WebSocket sub-specification (optional; if omitted, assume it matches C<version>)
+C<< $scope->{pagi}{spec_version} >> (String) -- The version of this WebSocket sub-specification (e.g. C<'0.3'>; optional only when it matches C<version>)
 
 =item -
 

--- a/lib/PAGI/Spec/Www.pod
+++ b/lib/PAGI/Spec/Www.pod
@@ -41,6 +41,12 @@ C<0.1>: Initial draft, based on ASGI 2.5, including Server-Sent Events support.
 
 =back
 
+C<< $scope->{pagi}{spec_version} >> reports which version of this specification
+governs an HTTP, WebSocket, or SSE connection. It is optional; if omitted,
+applications MUST assume C<'0.1'>. Omitting it declares support for version 0.1
+only, so the server MUST NOT use behaviour introduced by a later version on
+that connection. The core PAGI C<version> does not affect this default.
+
 =head2 Common Data Types
 
 =head3 Headers Format
@@ -317,7 +323,7 @@ C<< $scope->{pagi}{version} >> (String) -- The PAGI core spec version (e.g. C<'0
 
 =item -
 
-C<< $scope->{pagi}{spec_version} >> (String) -- The version of this HTTP sub-specification (e.g. C<'0.3'>; optional only when it matches C<version>)
+C<< $scope->{pagi}{spec_version} >> (String) -- The version of this HTTP sub-specification (e.g. C<'0.3'>). Optional; if omitted, assume C<'0.1'>.
 
 =item -
 
@@ -1114,7 +1120,7 @@ C<< $scope->{pagi}{version} >> (String) -- The PAGI core spec version (e.g. C<'0
 
 =item -
 
-C<< $scope->{pagi}{spec_version} >> (String) -- The version of this WebSocket sub-specification (e.g. C<'0.3'>; optional only when it matches C<version>)
+C<< $scope->{pagi}{spec_version} >> (String) -- The version of this WebSocket sub-specification (e.g. C<'0.3'>). Optional; if omitted, assume C<'0.1'>.
 
 =item -
 

--- a/lib/PAGI/Spec/Www.pod
+++ b/lib/PAGI/Spec/Www.pod
@@ -426,15 +426,15 @@ C<trailers> (Int, default C<0>) -- C<1> if trailers will be sent after body via 
 B<Header byte safety.> Because header names and values cross into HTTP message
 framing, a server B<MUST NOT> emit a header whose name or value contains C<CR>
 (C<\x0D>), C<LF> (C<\x0A>), or C<NUL> (C<\x00>), nor a name containing any other
-control character. The server B<MUST> reject such a header by failing the
-C<send> (the reference server raises) rather than forwarding it or silently
-rewriting the offending bytes: letting C<CR>/C<LF> through permits HTTP response
-splitting (CRLF injection), while silently stripping them mutates the
-application's data without signalling the bug. This is the same guarantee
-C<sse.send> gives for its C<event> and C<id> fields (see L</Send SSE - C<send>
-event>): the server's emission path is the single point that guards the wire, so
-applications and frameworks MAY hold header values as opaque bytes and need not
-pre-validate them. (RFC 9110 S5.5; RFC 9112 S11.1.)
+control character. The server B<MUST> reject such a header by failing the Future
+returned by C<$send> rather than forwarding it or silently rewriting the
+offending bytes: letting C<CR>/C<LF> through permits HTTP response splitting
+(CRLF injection), while silently stripping them mutates the application's data
+without signalling the bug. This is the same guarantee C<sse.send> gives for
+its C<event> and C<id> fields (see L</Send SSE - C<send> event>): the server's
+emission path is the single point that guards the wire, so applications and
+frameworks MAY hold header values as opaque bytes and need not pre-validate
+them. (RFC 9110 S5.5; RFC 9112 S11.1.)
 
 =head3 Response Body - C<send> event
 
@@ -1904,6 +1904,12 @@ scopes. A server that cannot determine its outbound buffer state omits the key;
 applications MUST treat its absence as "flow-control introspection unavailable"
 (and the high-level helpers report a buffered amount of C<0>).
 
+The presence of C<pagi.transport> affects introspection, not the fundamental
+send contract. Applications self-pace by awaiting every C<$send> Future whether
+or not this object is present; the object additionally lets them observe queue
+depth and make an earlier policy decision to conflate, coalesce, shed load, or
+disconnect.
+
 The long-term goal is universal coverage: every scope type that produces a
 stream of outbound events provides C<pagi.transport>, across every transport a
 server supports, so an application need not know which transport or protocol
@@ -1925,10 +1931,12 @@ neither sends, receives, nor consumes queued messages.
 If a server provides C<pagi.transport>, it B<must> implement C<buffered_amount>.
 
 B<C<high_water_mark()>> -- Returns the buffered-byte threshold at or above which
-the server applies backpressure: a C<$send> that would exceed it blocks until
-the buffer drains. Applications use it to threshold relative to the ceiling
-rather than hard-coding a byte count. Returns C<undef> if the server has no
-fixed high-water mark.
+the server applies backpressure: the Future returned by a C<$send> that would
+exceed it remains pending until the buffer drains enough for the server to
+continue processing the event. Awaiting that Future suspends the application
+coroutine, not the Perl thread. Applications use the threshold relative to the
+ceiling rather than hard-coding a byte count. Returns C<undef> if the server has
+no fixed high-water mark.
 
 B<C<low_water_mark()>> -- Returns the buffered-byte threshold the buffer must
 fall back to before the server releases backpressure (the drain point). Returns


### PR DESCRIPTION
## Summary

- distinguish the canonical runtime PAGI coderef from an application-provider object
- define one-time `to_app` normalization for general-purpose runners
- keep startup and shutdown in the lifespan protocol rather than inferring object hooks
- remove the prescribed `new(app => ...)` / `run` server-class shape from PAGI conformance
- advance the core specification to 0.4 and Server integration guidance to 0.2
- make core and protocol versions independent, with conservative protocol defaults when `spec_version` is omitted
- centralize the `$send` Future completion, failure, post-close, and backpressure contract
- prepare distribution release 0.002002

## Verification

- `prove -lr t` — 3 files, 20 tests, PASS
- `dzil test` — built distribution, 3 files, 20 tests, PASS
- module version check — `PAGI 0.002002`
- `git diff --check origin/main...HEAD` — clean

## Follow-up

After this specification is reviewed and released, audit PAGI::Server against the clarified `$send` contract and implement application-provider normalization in its runner. The closed-filehandle `$send` regression already on PAGI::Server `main` remains an intentional release blocker until that resource failure correctly fails the returned Future.
